### PR TITLE
feat/lint-format

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
   plugins: ["@typescript-eslint"],
   extends: ["eslint:recommended", "plugin:prettier/recommended"],
   rules: {
-    "no-unused-vars": 0 // eslint/ts has doesn't play nice with interfaces/type imports
+    "no-unused-vars": 0 // eslint/ts doesn't play nice with interfaces imports consistently
   },
   env: {
     browser: true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,19 @@
+module.exports = {
+  ignorePatterns: ["node_modules", "**/lib/**", "!.eslintrc.js", "*highlight*"],
+  parserOptions: {
+    ecmaVersion: 2019,
+    sourceType: "module"
+  },
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint"],
+  extends: ["eslint:recommended", "plugin:prettier/recommended"],
+  rules: {
+    "no-unused-vars": 0 // eslint/ts has doesn't play nice with interfaces/type imports
+  },
+  env: {
+    browser: true,
+    node: true,
+    jest: true,
+    es6: true
+  }
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 # ignore __fixtures__ only until we can dogfood our own plugin
 **/__fixtures__/**
+highlight.pack.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1231,6 +1231,12 @@
         "@types/node": ">= 8"
       }
     },
+    "@types/eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
+      "dev": true
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -1246,6 +1252,12 @@
         "@types/node": "*"
       }
     },
+    "@types/json-schema": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
+      "integrity": "sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -1255,6 +1267,88 @@
       "version": "12.12.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.17.tgz",
       "integrity": "sha512-Is+l3mcHvs47sKy+afn2O1rV4ldZFU7W8101cNlOd+MRbjM4Onida8jSZnJdTe/0Pcf25g9BNIUsuugmE6puHA=="
+    },
+    "@typescript-eslint/eslint-plugin": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.20.0.tgz",
+      "integrity": "sha512-cimIdVDV3MakiGJqMXw51Xci6oEDEoPkvh8ggJe2IIzcc0fYqAxOXN6Vbeanahz6dLZq64W+40iUEc9g32FLDQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "2.20.0",
+        "eslint-utils": "^1.4.3",
+        "functional-red-black-tree": "^1.0.1",
+        "regexpp": "^3.0.0",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "regexpp": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.0.0.tgz",
+          "integrity": "sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==",
+          "dev": true
+        }
+      }
+    },
+    "@typescript-eslint/experimental-utils": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.20.0.tgz",
+      "integrity": "sha512-fEBy9xYrwG9hfBLFEwGW2lKwDRTmYzH3DwTmYbT+SMycmxAoPl0eGretnBFj/s+NfYBG63w/5c3lsvqqz5mYag==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.3",
+        "@typescript-eslint/typescript-estree": "2.20.0",
+        "eslint-scope": "^5.0.0"
+      }
+    },
+    "@typescript-eslint/parser": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.20.0.tgz",
+      "integrity": "sha512-o8qsKaosLh2qhMZiHNtaHKTHyCHc3Triq6aMnwnWj7budm3xAY9owSZzV1uon5T9cWmJRJGzTFa90aex4m77Lw==",
+      "dev": true,
+      "requires": {
+        "@types/eslint-visitor-keys": "^1.0.0",
+        "@typescript-eslint/experimental-utils": "2.20.0",
+        "@typescript-eslint/typescript-estree": "2.20.0",
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.20.0.tgz",
+      "integrity": "sha512-WlFk8QtI8pPaE7JGQGxU7nGcnk1ccKAJkhbVookv94ZcAef3m6oCE/jEDL6dGte3JcD7reKrA0o55XhBRiVT3A==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "eslint-visitor-keys": "^1.1.0",
+        "glob": "^7.1.6",
+        "is-glob": "^4.0.1",
+        "lodash": "^4.17.15",
+        "semver": "^6.3.0",
+        "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
     },
     "@zkochan/cmd-shim": {
       "version": "3.1.0",
@@ -2860,6 +2954,32 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
+      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+          "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
+      "integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "eslint-scope": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
@@ -3071,6 +3191,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
+      "dev": true
     },
     "fast-glob": {
       "version": "2.2.7",
@@ -5413,6 +5539,15 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
     },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -6391,6 +6526,15 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
       "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+    },
+    "tsutils": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz",
+      "integrity": "sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "description": "",
   "scripts": {
     "bootstrap": "npm install && npx lerna bootstrap --loglevel verbose",
-    "build:compile": "",
     "build": "tsc -b packages && lerna exec --scope effects-docs -- npm run build",
     "clean": "del 'packages/*/lib' 'packages/*/*.{tsbuildinfo}' 'packages/*/src/**/*.{map,d.ts}'",
-    "test": "lerna exec npm run test",
-    "format": "prettier --write ./packages/*/{test,src}/**/*.{js,ts}"
+    "format:dryrun": "prettier ./*.{js,ts} ./packages/*/{test,src}/**/*.{js,ts}",
+    "format": "npm run format:dryrun -- --write",
+    "lint": "eslint ./.?*.js packages/**/*.{js,ts} && npm run format:dryrun -- --check",
+    "test": "lerna exec npm run test"
   },
   "repository": {
     "type": "git",
@@ -21,8 +22,12 @@
     "url": "https://github.com/dpchamps/effectsjs/issues"
   },
   "homepage": "https://github.com/dpchamps/effectsjs#readme",
-  "dependencies": {
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^2.20.0",
+    "@typescript-eslint/parser": "^2.20.0",
     "del-cli": "^3.0.0",
+    "eslint-config-prettier": "^6.10.0",
+    "eslint-plugin-prettier": "^3.1.2",
     "eslint": "^6.8.0",
     "lerna": "^3.20.2",
     "prettier": "^1.19.1",

--- a/packages/effects-runtime/babel.config.js
+++ b/packages/effects-runtime/babel.config.js
@@ -1,8 +1,8 @@
-const transformEffects = require('babel-plugin-effects');
+const transformEffects = require("babel-plugin-effects");
 
-module.exports = function(api){
-    api.cache(false);
-    return {
-        plugins: [transformEffects]
-    }
+module.exports = function(api) {
+  api.cache(false);
+  return {
+    plugins: [transformEffects]
+  };
 };

--- a/packages/effects-runtime/jest.config.js
+++ b/packages/effects-runtime/jest.config.js
@@ -2,193 +2,190 @@
 // https://jestjs.io/docs/en/configuration.html
 
 module.exports = {
-    // All imported modules in your tests should be mocked automatically
-    // automock: false,
+  // All imported modules in your tests should be mocked automatically
+  // automock: false,
 
-    // Stop running tests after `n` failures
-    // bail: 0,
+  // Stop running tests after `n` failures
+  // bail: 0,
 
-    // Respect "browser" field in package.json when resolving modules
-    // browser: false,
+  // Respect "browser" field in package.json when resolving modules
+  // browser: false,
 
-    // The directory where Jest should store its cached dependency information
-    // cacheDirectory: "/private/var/folders/82/y7tgy635119_jydjj_gyhlym0000gp/T/jest_dy",
+  // The directory where Jest should store its cached dependency information
+  // cacheDirectory: "/private/var/folders/82/y7tgy635119_jydjj_gyhlym0000gp/T/jest_dy",
 
-    // Automatically clear mock calls and instances between every test
-    clearMocks: true,
+  // Automatically clear mock calls and instances between every test
+  clearMocks: true,
 
-    // Indicates whether the coverage information should be collected while executing the test
-    // collectCoverage: false,
+  // Indicates whether the coverage information should be collected while executing the test
+  // collectCoverage: false,
 
-    // An array of glob patterns indicating a set of files for which coverage information should be collected
-    // collectCoverageFrom: null,
+  // An array of glob patterns indicating a set of files for which coverage information should be collected
+  // collectCoverageFrom: null,
 
-    // The directory where Jest should output its coverage files
-    coverageDirectory: "coverage",
+  // The directory where Jest should output its coverage files
+  coverageDirectory: "coverage",
 
-    // An array of regexp pattern strings used to skip coverage collection
-    coveragePathIgnorePatterns: [
-        "/node_modules/",
-        "/test/mocks/",
-        "/test/__fixtures__",
-        "/lib/",
-        "babel.config.js"
-    ],
+  // An array of regexp pattern strings used to skip coverage collection
+  coveragePathIgnorePatterns: [
+    "/node_modules/",
+    "/test/mocks/",
+    "/test/__fixtures__",
+    "/lib/",
+    "babel.config.js"
+  ],
 
-    // A list of reporter names that Jest uses when writing coverage reports
-    coverageReporters: [
-        //   "json",
-        "text",
-        "lcov",
-        //   "clover"
-        "html"
-    ],
-
-    // An object that configures minimum threshold enforcement for coverage results
-    // coverageThreshold: null,
-
-    // A path to a custom dependency extractor
-    // dependencyExtractor: null,
-
-    // Make calling deprecated APIs throw helpful error messages
-    // errorOnDeprecated: false,
-
-    // Force coverage collection from ignored files using an array of glob patterns
-    // forceCoverageMatch: [],
-
-    // A path to a module which exports an async function that is triggered once before all test suites
-    // globalSetup: null,
-
-    // A path to a module which exports an async function that is triggered once after all test suites
-    // globalTeardown: null,
-
-    // A set of global variables that need to be available in all test environments
-    // globals: {},
-
-    // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
-    // maxWorkers: "50%",
-
-    // An array of directory names to be searched recursively up from the requiring module's location
-    // moduleDirectories: [
-    //   "node_modules"
-    // ],
-
-    // An array of file extensions your modules use
-    // moduleFileExtensions: [
-    //   "js",
+  // A list of reporter names that Jest uses when writing coverage reports
+  coverageReporters: [
     //   "json",
-    //   "jsx",
-    //   "ts",
-    //   "tsx",
-    //   "node"
-    // ],
+    "text",
+    "lcov",
+    //   "clover"
+    "html"
+  ],
 
-    // A map from regular expressions to module names that allow to stub out resources with a single module
-    // moduleNameMapper: {},
+  // An object that configures minimum threshold enforcement for coverage results
+  // coverageThreshold: null,
 
-    // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
-    // modulePathIgnorePatterns: [],
+  // A path to a custom dependency extractor
+  // dependencyExtractor: null,
 
-    // Activates notifications for test results
-    // notify: false,
+  // Make calling deprecated APIs throw helpful error messages
+  // errorOnDeprecated: false,
 
-    // An enum that specifies notification mode. Requires { notify: true }
-    // notifyMode: "failure-change",
+  // Force coverage collection from ignored files using an array of glob patterns
+  // forceCoverageMatch: [],
 
-    // A preset that is used as a base for Jest's configuration
-    preset: 'ts-jest',
+  // A path to a module which exports an async function that is triggered once before all test suites
+  // globalSetup: null,
 
-    // Run tests from one or more projects
-    // projects: null,
+  // A path to a module which exports an async function that is triggered once after all test suites
+  // globalTeardown: null,
 
-    // Use this configuration option to add custom reporters to Jest
-    // reporters: undefined,
+  // A set of global variables that need to be available in all test environments
+  // globals: {},
 
-    // Automatically reset mock state between every test
-    // resetMocks: false,
+  // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+  // maxWorkers: "50%",
 
-    // Reset the module registry before running each individual test
-    // resetModules: false,
+  // An array of directory names to be searched recursively up from the requiring module's location
+  // moduleDirectories: [
+  //   "node_modules"
+  // ],
 
-    // A path to a custom resolver
-    // resolver: null,
+  // An array of file extensions your modules use
+  // moduleFileExtensions: [
+  //   "js",
+  //   "json",
+  //   "jsx",
+  //   "ts",
+  //   "tsx",
+  //   "node"
+  // ],
 
-    // Automatically restore mock state between every test
-    // restoreMocks: false,
+  // A map from regular expressions to module names that allow to stub out resources with a single module
+  // moduleNameMapper: {},
 
-    // The root directory that Jest should scan for tests and modules within
-    rootDir: null,
+  // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+  // modulePathIgnorePatterns: [],
 
-    // A list of paths to directories that Jest should use to search for files in
-    // roots: [
-    //   "<rootDir>"
-    // ],
+  // Activates notifications for test results
+  // notify: false,
 
-    // Allows you to use a custom runner instead of Jest's default test runner
-    // runner: "jest-runner",
+  // An enum that specifies notification mode. Requires { notify: true }
+  // notifyMode: "failure-change",
 
-    // The paths to modules that run some code to configure or set up the testing environment before each test
-    // setupFiles: [],
+  // A preset that is used as a base for Jest's configuration
+  preset: "ts-jest",
 
-    // A list of paths to modules that run some code to configure or set up the testing framework before each test
-    // setupFilesAfterEnv: [],
+  // Run tests from one or more projects
+  // projects: null,
 
-    // A list of paths to snapshot serializer modules Jest should use for snapshot testing
-    // snapshotSerializers: [],
+  // Use this configuration option to add custom reporters to Jest
+  // reporters: undefined,
 
-    // The test environment that will be used for testing
-    testEnvironment: "node",
+  // Automatically reset mock state between every test
+  // resetMocks: false,
 
-    // Options that will be passed to the testEnvironment
-    // testEnvironmentOptions: {},
+  // Reset the module registry before running each individual test
+  // resetModules: false,
 
-    // Adds a location field to test results
-    // testLocationInResults: false,
+  // A path to a custom resolver
+  // resolver: null,
 
-    // The glob patterns Jest uses to detect test files
-    // testMatch: [
-    //   "**/__tests__/**/*.[jt]s?(x)",
-    //   "**/?(*.)+(spec|test).[tj]s?(x)"
-    // ],
+  // Automatically restore mock state between every test
+  // restoreMocks: false,
 
-    // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-    testPathIgnorePatterns: [
-        "/node_modules/",
-        "/babel/"
-    ],
+  // The root directory that Jest should scan for tests and modules within
+  rootDir: null,
 
-    // The regexp pattern or array of patterns that Jest uses to detect test files
-    // testRegex: [],
+  // A list of paths to directories that Jest should use to search for files in
+  // roots: [
+  //   "<rootDir>"
+  // ],
 
-    // This option allows the use of a custom results processor
-    // testResultsProcessor: null,
+  // Allows you to use a custom runner instead of Jest's default test runner
+  // runner: "jest-runner",
 
-    // This option allows use of a custom test runner
-    // testRunner: "jasmine2",
+  // The paths to modules that run some code to configure or set up the testing environment before each test
+  // setupFiles: [],
 
-    // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
-    // testURL: "http://localhost",
+  // A list of paths to modules that run some code to configure or set up the testing framework before each test
+  // setupFilesAfterEnv: [],
 
-    // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
-    // timers: "real",
+  // A list of paths to snapshot serializer modules Jest should use for snapshot testing
+  // snapshotSerializers: [],
 
-    // A map from regular expressions to paths to transformers
-    // transform: null,
+  // The test environment that will be used for testing
+  testEnvironment: "node",
 
-    // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-    // transformIgnorePatterns: [
-    //   "/node_modules/"
-    // ],
+  // Options that will be passed to the testEnvironment
+  // testEnvironmentOptions: {},
 
-    // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
-    // unmockedModulePathPatterns: undefined,
+  // Adds a location field to test results
+  // testLocationInResults: false,
 
-    // Indicates whether each individual test should be reported during the run
-    // verbose: null,
+  // The glob patterns Jest uses to detect test files
+  // testMatch: [
+  //   "**/__tests__/**/*.[jt]s?(x)",
+  //   "**/?(*.)+(spec|test).[tj]s?(x)"
+  // ],
 
-    // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
-    // watchPathIgnorePatterns: [],
+  // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+  testPathIgnorePatterns: ["/node_modules/", "/babel/"]
 
-    // Whether to use watchman for file crawling
-    // watchman: true,
+  // The regexp pattern or array of patterns that Jest uses to detect test files
+  // testRegex: [],
+
+  // This option allows the use of a custom results processor
+  // testResultsProcessor: null,
+
+  // This option allows use of a custom test runner
+  // testRunner: "jasmine2",
+
+  // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
+  // testURL: "http://localhost",
+
+  // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
+  // timers: "real",
+
+  // A map from regular expressions to paths to transformers
+  // transform: null,
+
+  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+  // transformIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+  // unmockedModulePathPatterns: undefined,
+
+  // Indicates whether each individual test should be reported during the run
+  // verbose: null,
+
+  // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+  // watchPathIgnorePatterns: [],
+
+  // Whether to use watchman for file crawling
+  // watchman: true,
 };

--- a/packages/effects-runtime/test/.eslintrc.js
+++ b/packages/effects-runtime/test/.eslintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    "require-yield": 0 // test fixtures may not always yield
+  }
+};


### PR DESCRIPTION
# problem

- in preparation for #5, we need our lint/format hygiene in order

# solution

- wire in default prettier/eslint. I usually run `standard-damn-it` to wire in a minimal "just works" config, however this time I did the classico hand-stitching together of a JS+TS eslint config, so as to stay more in line w/ Dave-style JS/TS