### PR TITLE
Add symbols, computed props to effects handlers

### DIFF
--- a/packages/effects-common/src/StackFrame.ts
+++ b/packages/effects-common/src/StackFrame.ts
@@ -1,5 +1,5 @@
 // Methods for managing the call stack as a linked list
-import { Handler, HandlerDefinition, HandlerType } from "./effects.types";
+import { Handler, HandlerDefinition, EffectType } from "./effects.types";
 import { exists, isIterator } from "./util";
 
 const ReturnFrame: unique symbol = Symbol("ReturnFrame");
@@ -20,7 +20,7 @@ export type FrameLink = StackFrame | Continuation | null;
 
 export const getHandler = (
   frame: StackFrame,
-  type: HandlerType
+  type: EffectType
 ): HandlerDefinition | null => {
   const handler = frame[HandlerReference];
 
@@ -36,7 +36,7 @@ export const getReturnFrame = (frame: any): FrameLink => frame[ReturnFrame];
 
 export const isHandlerType = (
   frame: StackFrame | Continuation | null,
-  type: HandlerType
+  type: EffectType
 ): frame is StackFrame => {
   if (!isIterator(frame)) return false;
   return getHandler(frame, type) !== null;
@@ -58,7 +58,7 @@ export const isRootContinuation = (fn: Continuation | StackFrame) =>
 
 export const findHandlerFrame = (
   frame: StackFrame,
-  type: HandlerType
+  type: EffectType
 ): StackFrame | null => {
   let frameWithHandler: FrameLink = frame;
 

--- a/packages/effects-common/src/StackFrame.ts
+++ b/packages/effects-common/src/StackFrame.ts
@@ -1,5 +1,5 @@
 // Methods for managing the call stack as a linked list
-import { Handler, HandlerDefinition } from "./effects.types";
+import { Handler, HandlerDefinition, HandlerType } from "./effects.types";
 import { exists, isIterator } from "./util";
 
 const ReturnFrame: unique symbol = Symbol("ReturnFrame");
@@ -20,11 +20,12 @@ export type FrameLink = StackFrame | Continuation | null;
 
 export const getHandler = (
   frame: StackFrame,
-  type: string | number
+  type: HandlerType
 ): HandlerDefinition | null => {
   const handler = frame[HandlerReference];
 
   if (exists(handler)) {
+    // @ts-ignore
     return handler[type] ?? null;
   }
 
@@ -35,7 +36,7 @@ export const getReturnFrame = (frame: any): FrameLink => frame[ReturnFrame];
 
 export const isHandlerType = (
   frame: StackFrame | Continuation | null,
-  type: string | number
+  type: HandlerType
 ): frame is StackFrame => {
   if (!isIterator(frame)) return false;
   return getHandler(frame, type) !== null;
@@ -57,7 +58,7 @@ export const isRootContinuation = (fn: Continuation | StackFrame) =>
 
 export const findHandlerFrame = (
   frame: StackFrame,
-  type: string | number
+  type: HandlerType
 ): StackFrame | null => {
   let frameWithHandler: FrameLink = frame;
 

--- a/packages/effects-common/src/effects.types.ts
+++ b/packages/effects-common/src/effects.types.ts
@@ -10,9 +10,9 @@ export interface Handler {
   [index: number]: HandlerDefinition;
 }
 
-export type HandlerType = string | number | symbol;
+export type EffectType = string | number | symbol;
 
 export interface Effect {
-  type: HandlerType;
+  type: EffectType;
   data?: any;
 }

--- a/packages/effects-common/src/effects.types.ts
+++ b/packages/effects-common/src/effects.types.ts
@@ -10,7 +10,9 @@ export interface Handler {
   [index: number]: HandlerDefinition;
 }
 
+export type HandlerType = string | number | symbol;
+
 export interface Effect {
-  type: string | number;
+  type: HandlerType;
   data?: any;
 }

--- a/packages/effects-common/src/mod.ts
+++ b/packages/effects-common/src/mod.ts
@@ -22,7 +22,7 @@ export class UnhandledEffectError extends TypeError {
   constructor({ type }: Effect) {
     super();
 
-    this.message = `Encountered an unhandled effect :${type}`;
+    this.message = `Encountered an unhandled effect :${String(type)}`;
   }
 }
 
@@ -75,10 +75,7 @@ export const stackResume = async (
   }
 };
 
-export const runProgram = async (root: Generator) => {
-  const result = await stackResume(root, null);
-  return result;
-};
+export const runProgram = async (root: Generator) => stackResume(root, null);
 
 export const performEffect = ({ type, ...data }: Effect) => async (
   currentFrame: Generator

--- a/packages/effects-runtime/src/runtime.ts
+++ b/packages/effects-runtime/src/runtime.ts
@@ -18,7 +18,7 @@ export class UnhandledEffectError extends TypeError {
   constructor({ type }: Effect) {
     super();
 
-    this.message = `Encountered an unhandled effect :${type}`;
+    this.message = `Encountered an unhandled effect :${String(type)}`;
   }
 }
 

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/computed-handlers.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/computed-handlers.js
@@ -1,0 +1,55 @@
+const symbolHandler = Symbol();
+const {computedHandler} = {};
+
+const main = async (fn) => {
+    try{
+        return fn();
+    }handle({type}){
+        switch(type){
+            case symbolHandler : recall 'symbol';
+            case computedHandler : recall 'computed';
+        }
+    }
+};
+
+const performSymbolHandler = async () => {
+    'use effects';
+    main(() => {
+        return perform {type : symbolHandler}
+    });
+};
+
+const performComputedHandler = async () => {
+    'use effects';
+    main(() => {
+        return perform {type : computedHandler}
+    })
+};
+
+const locallyScopedEffects = async () => {
+  'use effects';
+  const something = 'something';
+  try{
+      return perform {type : 'something'};
+  }handle({type}){
+      switch(type){
+          case something: return recall something;
+      }
+  }
+};
+
+module.exports.test = ({describe, it, code, expect}) => {
+    describe(`Computed props for effects handlers`, () => {
+        it('Should behave as expected when performing a symbol handler', async () => {
+            await expect(performSymbolHandler()).resolves.toBe('symbol');
+        });
+
+        it('Should behave as expected when performing a computed handler', async () => {
+            await expect(performComputedHandler()).resolves.toBe('computed');
+        });
+
+        it('Should handle locally scoped effect types', async () => {
+            await expect(locallyScopedEffects()).resolves.toBe('something');
+        })
+    });
+};

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/computed-handlers.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/computed-handlers.js
@@ -30,7 +30,7 @@ const locallyScopedEffects = async () => {
   'use effects';
   const something = 'something';
   try{
-      return perform {type : 'something'};
+      return perform {type : something};
   }handle({type}){
       switch(type){
           case something: return recall something;

--- a/packages/effects-runtime/test/__snapshots__/babel-plugin-transform-effects.spec.ts.snap
+++ b/packages/effects-runtime/test/__snapshots__/babel-plugin-transform-effects.spec.ts.snap
@@ -114,7 +114,7 @@ const main = () => {
     (function*() {
       yield withHandler(
         {
-          *throwErrorHandler(__e__, resume) {
+          *[throwErrorHandler](__e__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -138,6 +138,180 @@ const main = () => {
 module.exports.test = async ({ describe, it, expect }) => {
   it("Should handle errors within effects", async () => {
     await expect(main()).rejects.toThrowError();
+  });
+};
+
+
+`;
+
+exports[`transformEffects Transform proposed effects keywords into working JS computed-handlers.js: computed-handlers.js 1`] = `
+
+const symbolHandler = Symbol();
+const {computedHandler} = {};
+
+const main = async (fn) => {
+    try{
+        return fn();
+    }handle({type}){
+        switch(type){
+            case symbolHandler : recall 'symbol';
+            case computedHandler : recall 'computed';
+        }
+    }
+};
+
+const performSymbolHandler = async () => {
+    'use effects';
+    main(() => {
+        return perform {type : symbolHandler}
+    });
+};
+
+const performComputedHandler = async () => {
+    'use effects';
+    main(() => {
+        return perform {type : computedHandler}
+    })
+};
+
+const locallyScopedEffects = async () => {
+  'use effects';
+  const something = 'something';
+  try{
+      return perform {type : 'something'};
+  }handle({type}){
+      switch(type){
+          case something: return recall something;
+      }
+  }
+};
+
+module.exports.test = ({describe, it, code, expect}) => {
+    describe(\`Computed props for effects handlers\`, () => {
+        it('Should behave as expected when performing a symbol handler', async () => {
+            await expect(performSymbolHandler()).resolves.toBe('symbol');
+        });
+
+        it('Should behave as expected when performing a computed handler', async () => {
+            await expect(performComputedHandler()).resolves.toBe('computed');
+        });
+
+        it('Should handle locally scoped effect types', async () => {
+            await expect(locallyScopedEffects()).resolves.toBe('something');
+        })
+    });
+};
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const symbolHandler = Symbol();
+const { computedHandler } = {};
+
+const main = async function*(fn) {
+  return yield withHandler(
+    {
+      *[symbolHandler](__e__, resume) {
+        const result = yield function(handler) {
+          return new Promise(async (res, rej) => {
+            try {
+              return stackResume(handler, "symbol")
+                .then(res)
+                .catch(rej);
+            } catch (handlerError) {
+              rej(handlerError);
+            }
+          });
+        };
+        return yield resume(result);
+      },
+
+      *[computedHandler](__e__, resume) {
+        const result = yield function(handler) {
+          return new Promise(async (res, rej) => {
+            try {
+              return stackResume(handler, "computed")
+                .then(res)
+                .catch(rej);
+            } catch (handlerError) {
+              rej(handlerError);
+            }
+          });
+        };
+        return yield resume(result);
+      }
+    },
+    (async function*() {
+      return yield fn();
+    })()
+  );
+};
+
+const performSymbolHandler = async () => {
+  return runProgram(
+    (function*() {
+      yield main(function*() {
+        return yield performEffect({
+          type: symbolHandler
+        });
+      });
+    })()
+  );
+};
+
+const performComputedHandler = async () => {
+  return runProgram(
+    (function*() {
+      yield main(function*() {
+        return yield performEffect({
+          type: computedHandler
+        });
+      });
+    })()
+  );
+};
+
+const locallyScopedEffects = async () => {
+  return runProgram(
+    (function*() {
+      const something = "something";
+      yield withHandler(
+        {
+          *[something](__e__, resume) {
+            const result = yield function(handler) {
+              return new Promise(async (res, rej) => {
+                try {
+                  return stackResume(handler, something)
+                    .then(res)
+                    .catch(rej);
+                } catch (handlerError) {
+                  rej(handlerError);
+                }
+              });
+            };
+            return yield resume(result);
+          }
+        },
+        (async function*() {
+          return yield performEffect({
+            type: "something"
+          });
+        })()
+      );
+    })()
+  );
+};
+
+module.exports.test = ({ describe, it, code, expect }) => {
+  describe(\`Computed props for effects handlers\`, () => {
+    it("Should behave as expected when performing a symbol handler", async () => {
+      await expect(performSymbolHandler()).resolves.toBe("symbol");
+    });
+    it("Should behave as expected when performing a computed handler", async () => {
+      await expect(performComputedHandler()).resolves.toBe("computed");
+    });
+    it("Should handle locally scoped effect types", async () => {
+      await expect(locallyScopedEffects()).resolves.toBe("something");
+    });
   });
 };
 
@@ -538,7 +712,7 @@ const syncEjectCase = () => {
     (function*() {
       yield withHandler(
         {
-          *throwErrorHandler(__e__, resume) {
+          *[ejectType](__e__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -568,7 +742,7 @@ const asyncEjectCase = async () => {
     (function*() {
       yield withHandler(
         {
-          *throwErrorHandler(__e__, resume) {
+          *[ejectType](__e__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -601,7 +775,7 @@ const continuationEjectCase = () => {
     (function*() {
       yield withHandler(
         {
-          *throwErrorHandler(__e__, resume) {
+          *[ejectType](__e__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -959,7 +1133,7 @@ const main = async () => {
     (function*() {
       yield withHandler(
         {
-          *getInteger(__e__, resume) {
+          *[getIntegerHandler](__e__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -1041,7 +1215,7 @@ const main = ({ onEffectComplete }) => {
     (function*() {
       yield withHandler(
         {
-          *getAsyncInteger(__e__, resume) {
+          *[getAsyncIntegerHandler](__e__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -1115,7 +1289,7 @@ const main = async () => {
     (function*() {
       yield withHandler(
         {
-          *getInteger(__e__, resume) {
+          *[getIntegerHandler](__e__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -1257,7 +1431,7 @@ const EffectC = () => ({
 const main = function*(fn) {
   return yield withHandler(
     {
-      *typeA(__e__, resume) {
+      *[effectTypeA](__e__, resume) {
         const result = yield function(handler) {
           return new Promise(async (res, rej) => {
             try {
@@ -1276,7 +1450,7 @@ const main = function*(fn) {
         return yield resume(result);
       },
 
-      *typeB(__e__, resume) {
+      *[effectTypeB](__e__, resume) {
         const result = yield function(handler) {
           return new Promise(async (res, rej) => {
             try {
@@ -1295,7 +1469,7 @@ const main = function*(fn) {
         return yield resume(result);
       },
 
-      *typeC(__e__, resume) {
+      *[effectTypeC](__e__, resume) {
         const result = yield function(handler) {
           return new Promise(async (res, rej) => {
             try {
@@ -1432,7 +1606,7 @@ const main = async () => {
     (function*() {
       yield withHandler(
         {
-          *throwErrorHandler(__e__, resume) {
+          *[gatherBananasEffectType](__e__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {

--- a/packages/effects-runtime/test/__snapshots__/babel-plugin-transform-effects.spec.ts.snap
+++ b/packages/effects-runtime/test/__snapshots__/babel-plugin-transform-effects.spec.ts.snap
@@ -178,7 +178,7 @@ const locallyScopedEffects = async () => {
   'use effects';
   const something = 'something';
   try{
-      return perform {type : 'something'};
+      return perform {type : something};
   }handle({type}){
       switch(type){
           case something: return recall something;
@@ -293,7 +293,7 @@ const locallyScopedEffects = async () => {
         },
         (async function*() {
           return yield performEffect({
-            type: "something"
+            type: something
           });
         })()
       );

--- a/packages/effects-runtime/test/effects.spec.ts
+++ b/packages/effects-runtime/test/effects.spec.ts
@@ -350,5 +350,36 @@ describe("Effects Unit Tests", () => {
 
       stackResume(controlFrame);
     });
+
+    it("Should handle symbol-y typed effect-handles", async () => {
+      const handlerType = Symbol();
+      const expectedResult = Symbol();
+
+      const handler: Handler = {
+        *[handlerType](_, resume) {
+          return yield resume(expectedResult);
+        }
+      };
+
+      const controlFrame = (function* main() {
+        return yield performEffect({ type: handlerType });
+      })();
+
+      addHandler(controlFrame, handler);
+
+      await expect(stackResume(controlFrame)).resolves.toBe(expectedResult);
+    });
+
+    it("Should catch unhandled symbol-y typed effect-handlers", async () => {
+      await expect(
+        stackResume(
+          (function* main() {
+            return yield performEffect({ type: Symbol("oh noes") });
+          })()
+        )
+      ).rejects.toThrowError(
+        "Encountered an unhandled effect :Symbol(oh noes)"
+      );
+    });
   });
 });


### PR DESCRIPTION
closes #7

## problem

Effect handler types were limited to locally-declared, stringly-typed variables. 

## solution

Preform the transformation more intelligently, allow for computed properties on the handler object.