### PR TITLE
 New Handler Grammar Implementation

### DIFF
--- a/packages/babel-plugin-effects/src/handler-method-visitor.ts
+++ b/packages/babel-plugin-effects/src/handler-method-visitor.ts
@@ -1,29 +1,19 @@
-import { NodePath, Visitor } from "@babel/traverse";
+import { NodePath } from "@babel/traverse";
 import BabelTypes, {
-  BigIntLiteral,
-  BooleanLiteral,
-  ExpressionStatement,
-  Identifier,
-  IfStatement,
-  MemberExpression,
-  NumericLiteral,
-  StringLiteral,
-  SwitchCase
+    BigIntLiteral,
+    BooleanLiteral,
+    ExpressionStatement,
+    Identifier,
+    IfStatement,
+    MemberExpression,
+    NumericLiteral, ObjectExpression, ObjectPattern,
+    StringLiteral,
+    SwitchCase
 } from "@babel/types";
-import {
-  TypesVisitorPrototype,
-  HandlerCreationPrototype
-} from "./visitor-proto-interfaces";
+import {collapseObjectPattern} from "./traverse-utilities";
+import {recallVisitor} from "./recall-visitor";
 
-const isCorrectMemberPropertyPath = (
-  types: typeof BabelTypes,
-  memberPropertyNode: BabelTypes.Node
-) => {
-  return (
-    types.isIdentifier(memberPropertyNode) ||
-    types.isStringLiteral(memberPropertyNode)
-  );
-};
+
 
 const isLiteralProp = (
   node: NodePath,
@@ -51,17 +41,18 @@ const extractMemberPropertyPathName = (
       return { ident: memberPropertyNode, isComputed: true };
     }
 
-    // I think at this point it's safe to throw.
+  }else if(parentPath.get('defaultMatcher').node){
+    return { ident: types.identifier('__defaultEffectHandler__'), isComputed : true}
   }
 
   throw new Error(
-    `[Babel Effects Transform Error] - Failed to construct handler. Could not find a valid definition for handler name`
+      `[Babel Effects Transform Error] - Failed to construct handler. Could not find a valid definition for handler name`
   );
 };
 
 const makeHandlerMethod = (
   memberPropertyPath: NodePath<MemberExpression | Identifier>,
-  rootPath: NodePath<IfStatement | SwitchCase>,
+  rootPath: NodePath<IfStatement | SwitchCase | any>,
   types: typeof BabelTypes,
   consequent: any,
   handlerParamName: string,
@@ -139,7 +130,7 @@ const makeHandlerMethod = (
   const objectMethod = types.objectMethod(
     "method",
     handlerPropertyName ? handlerPropertyName : memberPropertyPath.node,
-    [types.identifier(`__${handlerParamName}__`), types.identifier("resume")],
+    [types.identifier(`${handlerParamName}`), types.identifier("resume")],
     types.blockStatement([
       resultContinuation,
       types.returnStatement(
@@ -158,81 +149,40 @@ const makeHandlerMethod = (
   return objectMethod;
 };
 
-/**
- * From within a handle block,
- *
- * Visit each if statement and determine whether or not the test statement conforms to the expected definition for
- * an effects handler.
- */
-export const handlerMethodVisitor: Visitor<TypesVisitorPrototype &
-  HandlerCreationPrototype> = {
-  Identifier(path, { handlerParamName }) {
-    if (path.node.name === handlerParamName) {
-      path.node.name = `__${path.node.name}__`;
-    }
-  },
-  IfStatement(
-    path,
-    { types, handlerObject, handlerParamName, defaultAssignments }
-  ) {
-    const testPath = path.get("test");
-    const consequent = path.get("consequent") as any;
-    const memberPropertyPath = path.get("test.right") as NodePath<
-      MemberExpression
-    >;
+// Annoying:
+// For now, cannot traverse the HandlerClause node like it was a normal AST node
+// without further customization of the babel fork.
+export const followHandlerDefinitions = (
+    handlerPath : NodePath<any>,
+    handlerObject : ObjectExpression,
+    types : typeof BabelTypes
+) => {
+    const handlerBody = handlerPath.get('body');
+    const handlerParam = handlerPath.get('param').node as Identifier|ObjectPattern;
 
-    if (!types.isBinaryExpression(testPath.node)) return;
-    if (!["==", "==="].includes(testPath.node.operator)) return;
-    if (!types.isMemberExpression(testPath.node.left)) return;
-    if (!memberPropertyPath) return;
-    if (!isCorrectMemberPropertyPath(types, memberPropertyPath.node)) return;
+    const {
+        identifier,
+        defaultAssignments
+    }: {
+        identifier: Identifier;
+        defaultAssignments: ExpressionStatement[];
+    } = types.isObjectPattern(handlerParam)
+        ? collapseObjectPattern(handlerParam, types, handlerBody)
+        : { identifier: types.identifier(`__${handlerParam.name}__`), defaultAssignments: [] };
+
+    handlerBody.traverse(recallVisitor, { types });
+
 
     handlerObject.properties.push(
       makeHandlerMethod(
-        memberPropertyPath,
-        path,
-        types,
-        consequent,
-        handlerParamName,
-        defaultAssignments
+          handlerPath.get('effectMatcher'),
+          handlerPath,
+          types,
+          handlerPath.get('body'),
+          identifier.name,
+          defaultAssignments
       )
     );
-
-    const alternate = path.get("alternate");
-
-    if (alternate) {
-      path.traverse(handlerMethodVisitor, {
-        types,
-        handlerObject,
-        handlerParamName,
-        defaultAssignments
-      });
-    }
-
-    path.remove();
-  },
-  SwitchCase(
-    path,
-    { types, handlerObject, handlerParamName, defaultAssignments }
-  ) {
-    const memberPropertyPath = path.get("test") as NodePath<Identifier>;
-    const consequent = path.get("consequent") as any;
-
-    consequent.forEach(x => x.traverse(handlerMethodVisitor, { ...this }));
-
-    if (!memberPropertyPath) return;
-
-    handlerObject.properties.push(
-      makeHandlerMethod(
-        memberPropertyPath,
-        path,
-        types,
-        consequent[0],
-        handlerParamName,
-        defaultAssignments
-      )
-    );
-
-    path.remove();
-  }
+    const alternatePath = handlerPath.node.alternate ? handlerPath.get('alternate.handler') : null;
+    if(alternatePath) followHandlerDefinitions(alternatePath, handlerObject, types);
 };

--- a/packages/babel-plugin-effects/src/plugin.ts
+++ b/packages/babel-plugin-effects/src/plugin.ts
@@ -1,14 +1,9 @@
 import { parse } from "@babel/parser";
 import { NodePath, Visitor } from "@babel/traverse";
-import BabelTypes, {
-  ObjectExpression,
-  TryStatement
-} from "@babel/types";
+import BabelTypes, { ObjectExpression, TryStatement } from "@babel/types";
 import { effectsDirectiveVisitor } from "./effects-directive-visitor";
-import {followHandlerDefinitions} from "./handler-method-visitor";
-import {
-  fixupParentGenerator
-} from "./traverse-utilities";
+import { followHandlerDefinitions } from "./handler-method-visitor";
+import { fixupParentGenerator } from "./traverse-utilities";
 const parser = require("../../../babel/packages/babel-parser/lib");
 
 export interface Plugin {
@@ -22,10 +17,7 @@ export interface Babel {
   types: typeof BabelTypes;
 }
 
-function createHandler(
-  types: Babel["types"],
-  path: NodePath
-) {
+function createHandler(types: Babel["types"], path: NodePath) {
   const handlerObject = types.objectExpression([]);
 
   followHandlerDefinitions(path, handlerObject, types);
@@ -82,10 +74,9 @@ export default function transformEffects({ types }: Babel): Plugin {
           const handlerType = path.node.handler?.type;
 
           // @ts-ignore
-          if (handlerType !== "HandleClause" || !handlerBody)
-            return;
+          if (handlerType !== "HandleClause" || !handlerBody) return;
 
-          const handler = createHandler(types, path.get('handler'));
+          const handler = createHandler(types, path.get("handler"));
           const withHandlerExpression = createWithHandlerInvocation(
             types,
             path,

--- a/packages/babel-plugin-effects/src/traverse-utilities.ts
+++ b/packages/babel-plugin-effects/src/traverse-utilities.ts
@@ -114,10 +114,10 @@ export const toMemberExpressionVisitor: Visitor<{
   Identifier(path, { objectIdentifierName, propName, types }) {
     if (path.node.name === propName) {
       path.replaceWith(
-          types.memberExpression(
-              types.identifier(objectIdentifierName),
-              path.node
-          )
+        types.memberExpression(
+          types.identifier(objectIdentifierName),
+          path.node
+        )
       );
       path.skip();
     }
@@ -197,7 +197,7 @@ export const collapseObjectPattern = (
       });
     } else {
       handlerBodyPath.traverse(toMemberExpressionVisitor, {
-        objectIdentifierName : objectIdentifier.name,
+        objectIdentifierName: objectIdentifier.name,
         propName: property.key.name,
         types
       });

--- a/packages/babel-plugin-effects/src/traverse-utilities.ts
+++ b/packages/babel-plugin-effects/src/traverse-utilities.ts
@@ -107,13 +107,18 @@ export const fixupParentGenerator = (path: NodePath, types: Babel["types"]) => {
 };
 
 export const toMemberExpressionVisitor: Visitor<{
-  objectIdentifier: Identifier;
+  objectIdentifierName: string;
   propName: string;
   types: Babel["types"];
 }> = {
-  Identifier(path, { objectIdentifier, propName, types }) {
+  Identifier(path, { objectIdentifierName, propName, types }) {
     if (path.node.name === propName) {
-      path.replaceWith(types.memberExpression(objectIdentifier, path.node));
+      path.replaceWith(
+          types.memberExpression(
+              types.identifier(objectIdentifierName),
+              path.node
+          )
+      );
       path.skip();
     }
   }
@@ -171,7 +176,7 @@ export const collapseObjectPattern = (
   types: Babel["types"],
   handlerBodyPath: NodePath
 ): { identifier: Identifier; defaultAssignments: ExpressionStatement[] } => {
-  const identifierName = `e`;
+  const identifierName = `__e__`;
   const defaultAssignments: ExpressionStatement[] = [];
   const objectIdentifier = types.identifier(identifierName);
 
@@ -192,7 +197,7 @@ export const collapseObjectPattern = (
       });
     } else {
       handlerBodyPath.traverse(toMemberExpressionVisitor, {
-        objectIdentifier,
+        objectIdentifierName : objectIdentifier.name,
         propName: property.key.name,
         types
       });

--- a/packages/effects-common/src/StackFrame.ts
+++ b/packages/effects-common/src/StackFrame.ts
@@ -20,13 +20,14 @@ export type FrameLink = StackFrame | Continuation | null;
 
 export const getHandler = (
   frame: StackFrame,
-  type: EffectType
+  type: EffectType,
+  defaultType : EffectType | null = null
 ): HandlerDefinition | null => {
   const handler = frame[HandlerReference];
 
   if (exists(handler)) {
     // @ts-ignore
-    return handler[type] ?? null;
+    return exists(handler[type]) ? handler[type] :  handler[defaultType] ?? null;
   }
 
   return null;
@@ -58,11 +59,14 @@ export const isRootContinuation = (fn: Continuation | StackFrame) =>
 
 export const findHandlerFrame = (
   frame: StackFrame,
-  type: EffectType
+  type: EffectType,
+  defaultType: EffectType | null = null
 ): StackFrame | null => {
+
   let frameWithHandler: FrameLink = frame;
 
   while (exists(frameWithHandler) && !isHandlerType(frameWithHandler, type)) {
+    if(exists(defaultType) && isHandlerType(frameWithHandler, defaultType)) break;
     frameWithHandler = getReturnFrame(frameWithHandler);
   }
 

--- a/packages/effects-common/src/StackFrame.ts
+++ b/packages/effects-common/src/StackFrame.ts
@@ -21,13 +21,13 @@ export type FrameLink = StackFrame | Continuation | null;
 export const getHandler = (
   frame: StackFrame,
   type: EffectType,
-  defaultType : EffectType | null = null
+  defaultType: EffectType | null = null
 ): HandlerDefinition | null => {
   const handler = frame[HandlerReference];
 
   if (exists(handler)) {
     // @ts-ignore
-    return exists(handler[type]) ? handler[type] :  handler[defaultType] ?? null;
+    return exists(handler[type]) ? handler[type] : handler[defaultType] ?? null;
   }
 
   return null;
@@ -62,11 +62,11 @@ export const findHandlerFrame = (
   type: EffectType,
   defaultType: EffectType | null = null
 ): StackFrame | null => {
-
   let frameWithHandler: FrameLink = frame;
 
   while (exists(frameWithHandler) && !isHandlerType(frameWithHandler, type)) {
-    if(exists(defaultType) && isHandlerType(frameWithHandler, defaultType)) break;
+    if (exists(defaultType) && isHandlerType(frameWithHandler, defaultType))
+      break;
     frameWithHandler = getReturnFrame(frameWithHandler);
   }
 

--- a/packages/effects-common/src/effects.types.ts
+++ b/packages/effects-common/src/effects.types.ts
@@ -10,7 +10,7 @@ export interface Handler {
   [index: number]: HandlerDefinition;
 }
 
-export type EffectType = string | number | symbol;
+export type EffectType = string | number | symbol | undefined;
 
 export interface Effect {
   type: EffectType;

--- a/packages/effects-runtime/src/prelude-polyfill.ts
+++ b/packages/effects-runtime/src/prelude-polyfill.ts
@@ -1,4 +1,10 @@
-import { stackResume, withHandler, runProgram, performEffect, DefaultEffectHandler } from "./runtime";
+import {
+  stackResume,
+  withHandler,
+  runProgram,
+  performEffect,
+  DefaultEffectHandler
+} from "./runtime";
 
 // @ts-ignore
 global.stackResume = stackResume;

--- a/packages/effects-runtime/src/prelude-polyfill.ts
+++ b/packages/effects-runtime/src/prelude-polyfill.ts
@@ -1,4 +1,4 @@
-import { stackResume, withHandler, runProgram, performEffect } from "./runtime";
+import { stackResume, withHandler, runProgram, performEffect, DefaultEffectHandler } from "./runtime";
 
 // @ts-ignore
 global.stackResume = stackResume;
@@ -8,3 +8,5 @@ global.withHandler = withHandler;
 global.runProgram = runProgram;
 // @ts-ignore
 global.performEffect = performEffect;
+// @ts-ignore
+global.__defaultEffectHandler__ = DefaultEffectHandler;

--- a/packages/effects-runtime/src/runtime.ts
+++ b/packages/effects-runtime/src/runtime.ts
@@ -9,12 +9,14 @@ const {
     findHandlerFrame,
     getHandler,
     getReturnFrame,
-    isRootContinuation,
+    isRootContinuation
   },
-  util: { exists, isContinuation, isIterator },
+  util: { exists, isContinuation, isIterator }
 } = common;
 
-export const DefaultEffectHandler : unique symbol = Symbol('DefaultEffectHandler');
+export const DefaultEffectHandler: unique symbol = Symbol(
+  "DefaultEffectHandler"
+);
 
 export class UnhandledEffectError extends TypeError {
   constructor({ type }: Effect) {
@@ -81,14 +83,22 @@ export const runProgram = async (root: Generator) => {
 export const performEffect = ({ type, ...data }: Effect) => async (
   currentFrame: Generator
 ) => {
-  const frameWithEffectHandler = findHandlerFrame(currentFrame, type, DefaultEffectHandler);
+  const frameWithEffectHandler = findHandlerFrame(
+    currentFrame,
+    type,
+    DefaultEffectHandler
+  );
 
   if (!exists(frameWithEffectHandler)) {
     throw new UnhandledEffectError({ type });
   }
 
   // This is a GeneratorFunction, it will create the handler frame
-  const handlerFrameCreator = getHandler(frameWithEffectHandler, type, DefaultEffectHandler);
+  const handlerFrameCreator = getHandler(
+    frameWithEffectHandler,
+    type,
+    DefaultEffectHandler
+  );
 
   // TODO: [minor] Set up a type-guard on getHandler, or findHandlerFrame to indicate that at this point the handlerFrame must exist.
   if (!exists(handlerFrameCreator)) {

--- a/packages/effects-runtime/src/runtime.ts
+++ b/packages/effects-runtime/src/runtime.ts
@@ -9,10 +9,12 @@ const {
     findHandlerFrame,
     getHandler,
     getReturnFrame,
-    isRootContinuation
+    isRootContinuation,
   },
-  util: { exists, isContinuation, isIterator }
+  util: { exists, isContinuation, isIterator },
 } = common;
+
+export const DefaultEffectHandler : unique symbol = Symbol('DefaultEffectHandler');
 
 export class UnhandledEffectError extends TypeError {
   constructor({ type }: Effect) {
@@ -79,14 +81,14 @@ export const runProgram = async (root: Generator) => {
 export const performEffect = ({ type, ...data }: Effect) => async (
   currentFrame: Generator
 ) => {
-  const frameWithEffectHandler = findHandlerFrame(currentFrame, type);
+  const frameWithEffectHandler = findHandlerFrame(currentFrame, type, DefaultEffectHandler);
 
   if (!exists(frameWithEffectHandler)) {
     throw new UnhandledEffectError({ type });
   }
 
   // This is a GeneratorFunction, it will create the handler frame
-  const handlerFrameCreator = getHandler(frameWithEffectHandler, type);
+  const handlerFrameCreator = getHandler(frameWithEffectHandler, type, DefaultEffectHandler);
 
   // TODO: [minor] Set up a type-guard on getHandler, or findHandlerFrame to indicate that at this point the handlerFrame must exist.
   if (!exists(handlerFrameCreator)) {

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/async-parent-functions.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/async-parent-functions.js
@@ -2,7 +2,7 @@
 const entry = () => {
   try{
       throw new Error('error')
-  }handle(e){
+  }handle default with (e){
 
   }
 };

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/captured-continuation-error-handling.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/captured-continuation-error-handling.js
@@ -6,10 +6,8 @@ const main = () => {
     'use effects';
     try{
         perform ThrowErrorEffect();
-    }handle(e){
-        if(e.type === throwErrorHandler){
-            throw new Error('I am an error')
-        }
+    }handle throwErrorHandler with (e){
+        throw new Error('I am an error')
     }
 
 };

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/computed-handlers.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/computed-handlers.js
@@ -4,11 +4,10 @@ const {computedHandler} = {};
 const main = async (fn) => {
     try{
         return fn();
-    }handle({type}){
-        switch(type){
-            case symbolHandler : recall 'symbol';
-            case computedHandler : recall 'computed';
-        }
+    }handle symbolHandler with (_) {
+        recall 'symbol';
+    }handle computedHandler with (_){
+        recall 'computed';
     }
 };
 
@@ -31,10 +30,8 @@ const locallyScopedEffects = async () => {
   const something = 'something';
   try{
       return perform {type : something};
-  }handle({type}){
-      switch(type){
-          case something: return recall something;
-      }
+  }handle something with (_){
+      recall something;
   }
 };
 

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/default-handlers.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/default-handlers.js
@@ -1,0 +1,27 @@
+const effectType = Symbol();
+
+const main = async (data) => {
+    'use effects';
+  try{
+      let result = perform {type: effectType, data};
+      console.log(result)
+      result += perform {data : result};
+      console.log(result);
+
+      return result;
+  } handle effectType with ({data}){
+      recall (data + 1);
+  } handle default with ({data}){
+      recall (data * 2);
+  }
+};
+
+
+module.exports.test = ({it, expect, code}) => {
+    it('Should handle a non-explicitly declared effect when a default effect handler when present', async () => {
+        console.log(code)
+        const result = await main(1);
+
+        expect(result).toBe(6);
+    });
+};

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/default-handlers.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/default-handlers.js
@@ -4,9 +4,7 @@ const main = async (data) => {
     'use effects';
   try{
       let result = perform {type: effectType, data};
-      console.log(result)
       result += perform {data : result};
-      console.log(result);
 
       return result;
   } handle effectType with ({data}){
@@ -19,7 +17,6 @@ const main = async (data) => {
 
 module.exports.test = ({it, expect, code}) => {
     it('Should handle a non-explicitly declared effect when a default effect handler when present', async () => {
-        console.log(code)
         const result = await main(1);
 
         expect(result).toBe(6);

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/destructure.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/destructure.js
@@ -2,10 +2,8 @@ const typeDestructure = () => {
     'use effects';
     try{
         return perform {type : 'sayHi'};
-    }handle({type}){
-        if(type === 'sayHi'){
-            recall 'Hello :)'
-        }
+    }handle 'sayHi' with (e){
+        recall 'Hello :)'
     }
 };
 
@@ -16,11 +14,10 @@ const propDestructure = (mutableThing) => {
         mutableThing += perform {type : 'addTwo', data : mutableThing};
 
         return mutableThing;
-    }handle({type, data}){
-        switch(type){
-            case 'addOne' : return recall (data + 1);
-            case 'addTwo' : return recall (data + 2);
-        }
+    }handle 'addOne' with ({data}) {
+        recall(data + 1);
+    }handle 'addTwo' with ({data}) {
+        recall(data + 2);
     }
 };
 
@@ -28,13 +25,9 @@ const restDestructure = () => {
   'use effects'
   try{
       return perform {type : 'example', data1 : 'example 1 data 1', data2 : 'example 1 data 2'}
-  } handle({type, ...data}){
-      switch (type) {
-          case 'example': {
-              const {data1, data2} = data;
-              return recall [data1, data2];
-          }
-      }
+  } handle 'example' with ({...data}){
+      const {data1, data2} = data;
+      recall [data1, data2];
   }
 };
 
@@ -42,23 +35,9 @@ const defaultAssignments = () => {
     'use effects';
     try{
         return perform {type : 'getDefault'};
-    }handle({type, data = "default"}){
-        if(type === 'getDefault'){
-            recall data;
-        }
+    }handle 'getDefault' with ({data = "default"}){
+        recall data;
     }
-};
-
-const defaultEffectTypes = () => {
-  'use effects';
-
-  try{
-      return perform {data : "keanu: woah!"}
-  }handle({type = 'default', data}){
-      if(type === 'default'){
-          recall null;
-      }
-  }
 };
 
 module.exports.test = ({it, expect, describe, code}) => {
@@ -70,7 +49,8 @@ module.exports.test = ({it, expect, describe, code}) => {
         });
 
         it('Should destructure props from performed effects', async () => {
-           const result = await propDestructure(0);
+            console.log(code);
+            const result = await propDestructure(0);
            expect(result).toBe(4);
         });
 
@@ -85,13 +65,6 @@ module.exports.test = ({it, expect, describe, code}) => {
             const result = await defaultAssignments()
 
             expect(result).toBe('default');
-        });
-
-        // TODO: this seems desireable... Underlying runtime will need to be altered in order to make it a possibility.
-        it.skip('Should handle default types', async () => {
-            const result = await defaultEffectTypes()
-
-            expect(result).toBe('keanu: woah!');
         });
     });
 };

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/destructure.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/destructure.js
@@ -49,7 +49,6 @@ module.exports.test = ({it, expect, describe, code}) => {
         });
 
         it('Should destructure props from performed effects', async () => {
-            console.log(code);
             const result = await propDestructure(0);
            expect(result).toBe(4);
         });

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/errors-in-handlers.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/errors-in-handlers.js
@@ -24,10 +24,8 @@ const syncEjectCase = () => {
     'use effects';
     try{
         perform EjectEffect();
-    }handle(e){
-        if(e.type === ejectType){
-            syncEject();
-        }
+    }handle ejectType with (e){
+        syncEject();
     }
 };
 
@@ -35,10 +33,8 @@ const asyncEjectCase = async () => {
     'use effects';
     try{
         perform EjectEffect();
-    }handle(e){
-        if(e.type === ejectType){
-            await asyncEject();
-        }
+    }handle ejectType with (e){
+        await asyncEject();
     }
 };
 
@@ -46,10 +42,8 @@ const continuationEjectCase = () => {
   'use effects';
   try{
 
-  }handle(e){
-      if(e.type === ejectType){
-          continuationEject();
-      }
+  }handle ejectType with (e){
+      continuationEject();
   }
 };
 

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/nesting-handlers.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/nesting-handlers.js
@@ -2,20 +2,16 @@
 const mainEffectHandler = (input) => {
     try{
        return input()
-    }handle(e){
-        if(e.type === 'main'){
-            recall {value : "main"}
-        }
+    }handle 'main' with (e){
+        recall {value : "main"}
     }
 };
 
 const childEffectHandler = (input) => {
     try{
         return input();
-    }handle(e){
-        if(e.type === 'child'){
-            recall {value : "child"}
-        }
+    }handle 'child' with (e){
+        recall {value : "child"}
     }
 };
 

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/normal-functions.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/normal-functions.js
@@ -2,10 +2,8 @@
 const mainEffectHandler = (input) => {
     try{
         return input()
-    }handle(e){
-        if(e.type === 'main'){
-            recall {value : "main"}
-        }
+    }handle 'main' with (e){
+        recall {value : "main"}
     }
 };
 

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/perform-async-get-integer-control-flow.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/perform-async-get-integer-control-flow.js
@@ -8,10 +8,8 @@ const main = async () => {
     'use effects';
     try{
         return await asyncChild();
-    }handle(e){
-        if(e.type === getIntegerHandler){
-            recall expectation;
-        }
+    }handle getIntegerHandler with (e){
+        recall expectation;
     }
 };
 

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/perform-async-get-integer-handler.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/perform-async-get-integer-handler.js
@@ -10,12 +10,10 @@ const main = ({onEffectComplete}) => {
         const result = perform GetAsyncIntegerEffect();
 
         onEffectComplete(result);
-    }handle(e){
-        if(e.type === getAsyncIntegerHandler){
-            setTimeout(() => {
-                recall expectation;
-            }, 50)
-        }
+    }handle getAsyncIntegerHandler with (e){
+        setTimeout(() => {
+            recall expectation;
+        }, 50)
     }
 };
 

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/perform-get-integer.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/perform-get-integer.js
@@ -8,10 +8,8 @@ const main = async () => {
         const integer = perform GetIntegerEffect();
 
         return integer
-    }handle(e){
-        if(e.type === getIntegerHandler){
-            recall 5;
-        }
+    }handle getIntegerHandler with (e){
+        recall 5;
     }
 }
 

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/switch-statement.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/switch-statement.js
@@ -21,12 +21,12 @@ const cHandler = () => {
 const main = (fn) => {
     try{
         return fn();
-    }handle(e){
-        switch(e){
-            case effectTypeA : return aHandler();
-            case effectTypeB : return bHandler();
-            case effectTypeC : return cHandler();
-        }
+    }handle effectTypeA with (e) {
+        aHandler();
+    }handle effectTypeB with (e) {
+        bHandler();
+    }handle effectTypeC with (e) {
+        cHandler();
     }
 };
 

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/throwing-errors-from-timers.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/throwing-errors-from-timers.js
@@ -15,10 +15,8 @@ const main = async () => {
         if(someBananas === 'A Bunch Of Bananas'){
             throw new Error('I wanted Plantains!');
         }
-    }handle(e){
-        if(e.type === gatherBananasEffectType){
-            gatherBananasHandler();
-        }
+    }handle gatherBananasEffectType with (e){
+        gatherBananasHandler();
     }
 
 };

--- a/packages/effects-runtime/test/__snapshots__/babel-plugin-transform-effects.spec.ts.snap
+++ b/packages/effects-runtime/test/__snapshots__/babel-plugin-transform-effects.spec.ts.snap
@@ -333,9 +333,7 @@ const main = async (data) => {
     'use effects';
   try{
       let result = perform {type: effectType, data};
-      console.log(result)
       result += perform {data : result};
-      console.log(result);
 
       return result;
   } handle effectType with ({data}){
@@ -348,7 +346,6 @@ const main = async (data) => {
 
 module.exports.test = ({it, expect, code}) => {
     it('Should handle a non-explicitly declared effect when a default effect handler when present', async () => {
-        console.log(code)
         const result = await main(1);
 
         expect(result).toBe(6);
@@ -399,11 +396,9 @@ const main = async data => {
             type: effectType,
             data
           });
-          console.log(result);
           result += yield performEffect({
             data: result
           });
-          console.log(result);
           return result;
         })()
       );
@@ -413,7 +408,6 @@ const main = async data => {
 
 module.exports.test = ({ it, expect, code }) => {
   it("Should handle a non-explicitly declared effect when a default effect handler when present", async () => {
-    console.log(code);
     const result = await main(1);
     expect(result).toBe(6);
   });
@@ -475,7 +469,6 @@ module.exports.test = ({it, expect, describe, code}) => {
         });
 
         it('Should destructure props from performed effects', async () => {
-            console.log(code);
             const result = await propDestructure(0);
            expect(result).toBe(4);
         });
@@ -650,7 +643,6 @@ module.exports.test = ({ it, expect, describe, code }) => {
       expect(result).toBe("Hello :)");
     });
     it("Should destructure props from performed effects", async () => {
-      console.log(code);
       const result = await propDestructure(0);
       expect(result).toBe(4);
     });

--- a/packages/effects-runtime/test/effects-integrations.spec.ts
+++ b/packages/effects-runtime/test/effects-integrations.spec.ts
@@ -6,7 +6,8 @@ import {
   performEffect,
   runProgram,
   stackResume,
-  withHandler
+  withHandler,
+  DefaultEffectHandler
 } from "../src/runtime";
 import { Handler } from "effects-common";
 
@@ -280,4 +281,101 @@ describe("Effect Integrations", () => {
       runProgram(withHandler(handler, parent()));
     }).not.toThrow();
   });
+
+  test(`Should execute default effects handlers correctly`, async () => {
+    const specifiedEffectResult = Symbol();
+    const defaultEffectResult = Symbol();
+
+    const handler : Handler = {
+      *effect1(data, resume){
+        return yield resume(specifiedEffectResult);
+      },
+      *[DefaultEffectHandler](data, resume){
+        return yield resume(defaultEffectResult);
+      }
+    };
+
+    function* main(){
+      return [
+          yield performEffect({type : 'effect1'}),
+          yield performEffect({type : undefined})
+      ]
+    }
+
+    const [result1, result2] = await runProgram(withHandler(handler, main()));
+
+    expect(result1).toBe(specifiedEffectResult);
+    expect(result2).toBe(defaultEffectResult);
+
+  });
+
+  test('default handler in parent child hierarchies', async () => {
+    const defaultEffectResult = Symbol();
+    const specifiedEffectResult = Symbol();
+
+    const handler : Handler = {
+      *[DefaultEffectHandler](data, resume){
+        return yield resume(defaultEffectResult);
+      }
+    };
+
+    const childHandler : Handler = {
+      *effect(data, resume){
+        return yield resume(specifiedEffectResult)
+      }
+    };
+
+    function* parent(){
+      return yield withHandler(childHandler, child());
+    }
+
+    function* child() {
+      return [
+          yield performEffect({type : undefined}),
+          yield performEffect({type : 'effect'})
+      ]
+    }
+
+    const [result1, result2] = await runProgram(withHandler(handler, parent()));
+
+    expect(result1).toBe(defaultEffectResult);
+    expect(result2).toBe(specifiedEffectResult);
+  });
+
+  test('default handler specifies boundaries between child -> parent hierarchies', async () => {
+    const parentEffectResult = Symbol();
+    const childEffectResult = Symbol();
+
+    const parentHandler : Handler = {
+      *parentEffect(data, resume){
+        return yield resume(parentEffectResult)
+      }
+    };
+
+    const childHandler : Handler = {
+      *[DefaultEffectHandler](data, resume){
+        return yield resume(childEffectResult)
+      }
+    };
+
+    const program = withHandler(
+        parentHandler,
+        function*(){
+          return yield withHandler(
+              childHandler,
+              function* () {
+                return [
+                    yield performEffect({type : 'parentEffect'}),
+                    yield performEffect({type : 'non-exist'})
+                ]
+              }()
+          )
+        }()
+    );
+
+    const [result1, result2] = await runProgram(program);
+
+    expect(result1).toBe(childEffectResult);
+    expect(result2).toBe(childEffectResult);
+  })
 });

--- a/packages/effects-runtime/test/effects.spec.ts
+++ b/packages/effects-runtime/test/effects.spec.ts
@@ -3,7 +3,8 @@ import {
   runProgram,
   performEffect,
   withHandler,
-  UnhandledEffectError
+  UnhandledEffectError,
+    DefaultEffectHandler
 } from "../src/runtime";
 import { Handler } from "effects-common";
 import {
@@ -223,6 +224,26 @@ describe("Effects Unit Tests", () => {
       await expect(performContinuation(mockFrame())).rejects.toThrowError(
         UnhandledEffectError
       );
+    });
+
+    it('Should perform a default effect handler', async () => {
+      const handlerSpy = jest.fn();
+      const handler : Handler = {
+        *[DefaultEffectHandler](_, resume){
+          handlerSpy();
+          resume();
+        }
+      };
+
+      const controlFrame = (function*(){
+        yield performEffect({type : undefined});
+      })();
+
+      addHandler(controlFrame, handler);
+
+      await stackResume(controlFrame);
+
+      expect(handlerSpy).toHaveBeenCalledTimes(1);
     });
 
     it("Should call an effect handler", async () => {

--- a/packages/effects-runtime/test/effects.spec.ts
+++ b/packages/effects-runtime/test/effects.spec.ts
@@ -4,7 +4,7 @@ import {
   performEffect,
   withHandler,
   UnhandledEffectError,
-    DefaultEffectHandler
+  DefaultEffectHandler
 } from "../src/runtime";
 import { Handler } from "effects-common";
 import {
@@ -226,17 +226,17 @@ describe("Effects Unit Tests", () => {
       );
     });
 
-    it('Should perform a default effect handler', async () => {
+    it("Should perform a default effect handler", async () => {
       const handlerSpy = jest.fn();
-      const handler : Handler = {
-        *[DefaultEffectHandler](_, resume){
+      const handler: Handler = {
+        *[DefaultEffectHandler](_, resume) {
           handlerSpy();
           resume();
         }
       };
 
-      const controlFrame = (function*(){
-        yield performEffect({type : undefined});
+      const controlFrame = (function*() {
+        yield performEffect({ type: undefined });
       })();
 
       addHandler(controlFrame, handler);

--- a/packages/effects-runtime/test/functional-test-runner.spec.js
+++ b/packages/effects-runtime/test/functional-test-runner.spec.js
@@ -12,13 +12,13 @@ const FUNCTIONAL_TEST_DIRECTORY = path.resolve(
 const readAndParseFile = textFixtureBaseName => {
   const filename = path.resolve(FUNCTIONAL_TEST_DIRECTORY, textFixtureBaseName);
   const file = `require('../lib/prelude-polyfill');\n ${readFileSync(
-      filename,
-      "utf8"
+    filename,
+    "utf8"
   )}`;
 
-  try{
+  try {
     return transform(file).code;
-  }catch(e){
+  } catch (e) {
     throw new Error(`${filename} failed to parse with ${e.message}`);
   }
 };

--- a/packages/effects-runtime/test/functional-test-runner.spec.js
+++ b/packages/effects-runtime/test/functional-test-runner.spec.js
@@ -12,11 +12,15 @@ const FUNCTIONAL_TEST_DIRECTORY = path.resolve(
 const readAndParseFile = textFixtureBaseName => {
   const filename = path.resolve(FUNCTIONAL_TEST_DIRECTORY, textFixtureBaseName);
   const file = `require('../lib/prelude-polyfill');\n ${readFileSync(
-    filename,
-    "utf8"
+      filename,
+      "utf8"
   )}`;
 
-  return transform(file).code;
+  try{
+    return transform(file).code;
+  }catch(e){
+    throw new Error(`${filename} failed to parse with ${e.message}`);
+  }
 };
 
 const evaluateModule = code => nodeEval(code, "testFixtureModule");

--- a/test/__snapshots__/babel-plugin-transform-effects.spec.ts.snap
+++ b/test/__snapshots__/babel-plugin-transform-effects.spec.ts.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`transformEffects Transform proposed effects keywords into working JS async-parent-functions.js: async-parent-functions.js 1`] = `
+exports[`transformEffects Transform proposed effects keywords into working JS 1. Transform Effects: 1. Transform Effects 1`] = `
 
 const entry = () => {
   try{
       throw new Error('error')
-  }handle default with (e){
+  }handle(e){
 
   }
 };
@@ -38,19 +38,7 @@ module.exports.test = ({it, expect, code}) => {
 
 const entry = function*() {
   return yield withHandler(
-    {
-      *[__defaultEffectHandler__](__e__, resume) {
-        const result = yield function(handler) {
-          return new Promise(async (res, rej) => {
-            try {
-            } catch (handlerError) {
-              rej(handlerError);
-            }
-          });
-        };
-        return yield resume(result);
-      }
-    },
+    {},
     (async function*() {
       throw new Error("error");
     })()
@@ -89,7 +77,7 @@ module.exports.test = ({ it, expect, code }) => {
 
 `;
 
-exports[`transformEffects Transform proposed effects keywords into working JS captured-continuation-error-handling.js: captured-continuation-error-handling.js 1`] = `
+exports[`transformEffects Transform proposed effects keywords into working JS 2. Transform Effects: 2. Transform Effects 1`] = `
 
 const throwErrorHandler = 'throwErrorHandler';
 
@@ -99,8 +87,10 @@ const main = () => {
     'use effects';
     try{
         perform ThrowErrorEffect();
-    }handle throwErrorHandler with (e){
-        throw new Error('I am an error')
+    }handle(e){
+        if(e.type === throwErrorHandler){
+            throw new Error('I am an error')
+        }
     }
 
 };
@@ -124,7 +114,7 @@ const main = () => {
     (function*() {
       yield withHandler(
         {
-          *[throwErrorHandler](__e__, resume) {
+          *throwErrorHandler(__e__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -154,361 +144,135 @@ module.exports.test = async ({ describe, it, expect }) => {
 
 `;
 
-exports[`transformEffects Transform proposed effects keywords into working JS computed-handlers.js: computed-handlers.js 1`] = `
+exports[`transformEffects Transform proposed effects keywords into working JS 3. Transform Effects: 3. Transform Effects 1`] = `
 
-const symbolHandler = Symbol();
-const {computedHandler} = {};
+const {performance} = require('perf_hooks');
 
-const main = async (fn) => {
-    try{
-        return fn();
-    }handle symbolHandler with (_) {
-        recall 'symbol';
-    }handle computedHandler with (_){
-        recall 'computed';
-    }
-};
-
-const performSymbolHandler = async () => {
-    'use effects';
-    main(() => {
-        return perform {type : symbolHandler}
-    });
-};
-
-const performComputedHandler = async () => {
-    'use effects';
-    main(() => {
-        return perform {type : computedHandler}
-    })
-};
-
-const locallyScopedEffects = async () => {
-  'use effects';
-  const something = 'something';
-  try{
-      return perform {type : something};
-  }handle something with (_){
-      recall something;
+class Mutex{
+  constructor(initialValue) {
+      this.data = initialValue;
+      this.lock = Promise.resolve();
   }
-};
 
-module.exports.test = ({describe, it, code, expect}) => {
-    describe(\`Computed props for effects handlers\`, () => {
-        it('Should behave as expected when performing a symbol handler', async () => {
-            await expect(performSymbolHandler()).resolves.toBe('symbol');
-        });
+  async take(){
+      await this.lock;
 
-        it('Should behave as expected when performing a computed handler', async () => {
-            await expect(performComputedHandler()).resolves.toBe('computed');
-        });
-
-        it('Should handle locally scoped effect types', async () => {
-            await expect(locallyScopedEffects()).resolves.toBe('something');
-        })
-    });
-};
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-const symbolHandler = Symbol();
-const { computedHandler } = {};
-
-const main = async function*(fn) {
-  return yield withHandler(
-    {
-      *[symbolHandler](_____, resume) {
-        const result = yield function(handler) {
-          return new Promise(async (res, rej) => {
-            try {
-              return stackResume(handler, "symbol")
-                .then(res)
-                .catch(rej);
-            } catch (handlerError) {
-              rej(handlerError);
-            }
-          });
-        };
-        return yield resume(result);
-      },
-
-      *[computedHandler](_____, resume) {
-        const result = yield function(handler) {
-          return new Promise(async (res, rej) => {
-            try {
-              return stackResume(handler, "computed")
-                .then(res)
-                .catch(rej);
-            } catch (handlerError) {
-              rej(handlerError);
-            }
-          });
-        };
-        return yield resume(result);
-      }
-    },
-    (async function*() {
-      return yield fn();
-    })()
-  );
-};
-
-const performSymbolHandler = async () => {
-  return runProgram(
-    (function*() {
-      yield main(function*() {
-        return yield performEffect({
-          type: symbolHandler
-        });
+      let res;
+      this.lock = new Promise(_res => {
+          res = _res;
       });
-    })()
-  );
-};
-
-const performComputedHandler = async () => {
-  return runProgram(
-    (function*() {
-      yield main(function*() {
-        return yield performEffect({
-          type: computedHandler
-        });
-      });
-    })()
-  );
-};
-
-const locallyScopedEffects = async () => {
-  return runProgram(
-    (function*() {
-      const something = "something";
-      yield withHandler(
-        {
-          *[something](_____, resume) {
-            const result = yield function(handler) {
-              return new Promise(async (res, rej) => {
-                try {
-                  return stackResume(handler, something)
-                    .then(res)
-                    .catch(rej);
-                } catch (handlerError) {
-                  rej(handlerError);
-                }
-              });
-            };
-            return yield resume(result);
-          }
-        },
-        (async function*() {
-          return yield performEffect({
-            type: something
-          });
-        })()
-      );
-    })()
-  );
-};
-
-module.exports.test = ({ describe, it, code, expect }) => {
-  describe(\`Computed props for effects handlers\`, () => {
-    it("Should behave as expected when performing a symbol handler", async () => {
-      await expect(performSymbolHandler()).resolves.toBe("symbol");
-    });
-    it("Should behave as expected when performing a computed handler", async () => {
-      await expect(performComputedHandler()).resolves.toBe("computed");
-    });
-    it("Should handle locally scoped effect types", async () => {
-      await expect(locallyScopedEffects()).resolves.toBe("something");
-    });
-  });
-};
 
 
-`;
-
-exports[`transformEffects Transform proposed effects keywords into working JS default-handlers.js: default-handlers.js 1`] = `
-
-const effectType = Symbol();
-
-const main = async (data) => {
-    'use effects';
-  try{
-      let result = perform {type: effectType, data};
-      console.log(result)
-      result += perform {data : result};
-      console.log(result);
-
-      return result;
-  } handle effectType with ({data}){
-      recall (data + 1);
-  } handle default with ({data}){
-      recall (data * 2);
+      return (value) => {
+          console.log('resolving with', value);
+          this.data = value;
+          res();
+      };
   }
+}
+
+const someSingletonMutex = new Mutex({});
+
+
+const mainConcurrent = () => {
+    'use effects';
+    try{
+        perform {type : 'effect'};
+        return performance.now();
+    }handle(e){
+        if(e.type === 'effect'){
+            setTimeout(() => {
+                recall null;
+            }, 15);
+        }
+    }
 };
 
+const accessData = async (value) => {
+    const release = await someSingletonMutex.take();
 
-module.exports.test = ({it, expect, code}) => {
-    it('Should handle a non-explicitly declared effect when a default effect handler when present', async () => {
-        console.log(code)
-        const result = await main(1);
+    setTimeout(() => {
+        release(value);
+        recall null;
+    }, 15);
+};
 
-        expect(result).toBe(6);
+const mainMutex = async (value) => {
+    'use effects';
+    try{
+        perform({type : 'setData', data :value});
+        return performance.now();
+    }handle(e){
+        if(e.type === 'setData'){
+            await accessData(e.data)
+        }
+    }
+};
+
+module.exports.test = ({expect, it}) => {
+    it('Should call entries concurrently', async () => {
+        const [t1, t2] = await Promise.all([
+            mainConcurrent(),
+            mainConcurrent()
+        ]);
+
+        expect(Math.abs(t1 - t2)).toBeLessThan(1);
+    });
+
+    it('Should perform as expected with locked resources', async () => {
+        const [t1, t2] = await Promise.all([
+            mainMutex('A'),
+            new Promise(res => setTimeout(() => {
+                res(mainMutex('B'))
+            }, 1))
+        ]);
+
+        expect(t2).toBeGreaterThan(t1);
+        expect(t2-t1).toBeGreaterThan(15);
+        expect(someSingletonMutex.data).toBe('B')
     });
 };
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-const effectType = Symbol();
+const { performance } = require("perf_hooks");
 
-const main = async data => {
-  return runProgram(
-    (function*() {
-      yield withHandler(
-        {
-          *[effectType](__e__, resume) {
-            const result = yield function(handler) {
-              return new Promise(async (res, rej) => {
-                try {
-                  return stackResume(handler, __e__.data + 1)
-                    .then(res)
-                    .catch(rej);
-                } catch (handlerError) {
-                  rej(handlerError);
-                }
-              });
-            };
-            return yield resume(result);
-          },
-
-          *[__defaultEffectHandler__](__e__, resume) {
-            const result = yield function(handler) {
-              return new Promise(async (res, rej) => {
-                try {
-                  return stackResume(handler, __e__.data * 2)
-                    .then(res)
-                    .catch(rej);
-                } catch (handlerError) {
-                  rej(handlerError);
-                }
-              });
-            };
-            return yield resume(result);
-          }
-        },
-        (async function*() {
-          let result = yield performEffect({
-            type: effectType,
-            data
-          });
-          console.log(result);
-          result += yield performEffect({
-            data: result
-          });
-          console.log(result);
-          return result;
-        })()
-      );
-    })()
-  );
-};
-
-module.exports.test = ({ it, expect, code }) => {
-  it("Should handle a non-explicitly declared effect when a default effect handler when present", async () => {
-    console.log(code);
-    const result = await main(1);
-    expect(result).toBe(6);
-  });
-};
-
-
-`;
-
-exports[`transformEffects Transform proposed effects keywords into working JS destructure.js: destructure.js 1`] = `
-
-const typeDestructure = () => {
-    'use effects';
-    try{
-        return perform {type : 'sayHi'};
-    }handle 'sayHi' with (e){
-        recall 'Hello :)'
-    }
-};
-
-const propDestructure = (mutableThing) => {
-    'use effects';
-    try{
-        mutableThing += perform {type : 'addOne', data : mutableThing};
-        mutableThing += perform {type : 'addTwo', data : mutableThing};
-
-        return mutableThing;
-    }handle 'addOne' with ({data}) {
-        recall(data + 1);
-    }handle 'addTwo' with ({data}) {
-        recall(data + 2);
-    }
-};
-
-const restDestructure = () => {
-  'use effects'
-  try{
-      return perform {type : 'example', data1 : 'example 1 data 1', data2 : 'example 1 data 2'}
-  } handle 'example' with ({...data}){
-      const {data1, data2} = data;
-      recall [data1, data2];
+class Mutex {
+  constructor(initialValue) {
+    this.data = initialValue;
+    this.lock = Promise.resolve();
   }
-};
 
-const defaultAssignments = () => {
-    'use effects';
-    try{
-        return perform {type : 'getDefault'};
-    }handle 'getDefault' with ({data = "default"}){
-        recall data;
-    }
-};
-
-module.exports.test = ({it, expect, describe, code}) => {
-    describe('Destructuring effects handlers', () => {
-        it('Should destructure effect types in handle block', async () => {
-            const result = await typeDestructure();
-
-            expect(result).toBe('Hello :)');
-        });
-
-        it('Should destructure props from performed effects', async () => {
-            console.log(code);
-            const result = await propDestructure(0);
-           expect(result).toBe(4);
-        });
-
-        it('Should handle rest props correctly during the destructure', async () =>{
-            const [data1, data2] = await restDestructure();
-
-            expect(data1).toBe('example 1 data 1');
-            expect(data2).toBe('example 1 data 2');
-        });
-
-        it('Should handle default destructure props', async () => {
-            const result = await defaultAssignments()
-
-            expect(result).toBe('default');
-        });
+  async take() {
+    await this.lock;
+    let res;
+    this.lock = new Promise(_res => {
+      res = _res;
     });
-};
+    return value => {
+      console.log("resolving with", value);
+      this.data = value;
+      res();
+    };
+  }
+}
 
-      ↓ ↓ ↓ ↓ ↓ ↓
+const someSingletonMutex = new Mutex({});
 
-const typeDestructure = () => {
+const mainConcurrent = () => {
   return runProgram(
     (function*() {
       yield withHandler(
         {
-          *sayHi(__e__, resume) {
+          *effect(__e__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
-                  return stackResume(handler, "Hello :)")
-                    .then(res)
-                    .catch(rej);
+                  setTimeout(() => {
+                    return stackResume(handler, null)
+                      .then(res)
+                      .catch(rej);
+                  }, 15);
                 } catch (handlerError) {
                   rej(handlerError);
                 }
@@ -518,42 +282,36 @@ const typeDestructure = () => {
           }
         },
         (async function*() {
-          return yield performEffect({
-            type: "sayHi"
+          yield performEffect({
+            type: "effect"
           });
+          return performance.now();
         })()
       );
     })()
   );
 };
 
-const propDestructure = mutableThing => {
+const mainMutex = async value => {
   return runProgram(
     (function*() {
       yield withHandler(
         {
-          *addOne(__e__, resume) {
+          *setData(__e__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
-                  return stackResume(handler, __e__.data + 1)
-                    .then(res)
-                    .catch(rej);
-                } catch (handlerError) {
-                  rej(handlerError);
-                }
-              });
-            };
-            return yield resume(result);
-          },
+                  const accessData = async value => {
+                    const release = await someSingletonMutex.take();
+                    setTimeout(() => {
+                      release(value);
+                      return stackResume(handler, null)
+                        .then(res)
+                        .catch(rej);
+                    }, 15);
+                  };
 
-          *addTwo(__e__, resume) {
-            const result = yield function(handler) {
-              return new Promise(async (res, rej) => {
-                try {
-                  return stackResume(handler, __e__.data + 2)
-                    .then(res)
-                    .catch(rej);
+                  await accessData(__e__.data);
                 } catch (handlerError) {
                   rej(handlerError);
                 }
@@ -563,113 +321,41 @@ const propDestructure = mutableThing => {
           }
         },
         (async function*() {
-          mutableThing += yield performEffect({
-            type: "addOne",
-            data: mutableThing
+          yield performEffect({
+            type: "setData",
+            data: value
           });
-          mutableThing += yield performEffect({
-            type: "addTwo",
-            data: mutableThing
-          });
-          return mutableThing;
+          return performance.now();
         })()
       );
     })()
   );
 };
 
-const restDestructure = () => {
-  return runProgram(
-    (function*() {
-      yield withHandler(
-        {
-          *example(__e__, resume) {
-            const result = yield function(handler) {
-              return new Promise(async (res, rej) => {
-                try {
-                  const { data1, data2 } = __e__;
-                  return stackResume(handler, [data1, data2])
-                    .then(res)
-                    .catch(rej);
-                } catch (handlerError) {
-                  rej(handlerError);
-                }
-              });
-            };
-            return yield resume(result);
-          }
-        },
-        (async function*() {
-          return yield performEffect({
-            type: "example",
-            data1: "example 1 data 1",
-            data2: "example 1 data 2"
-          });
-        })()
-      );
-    })()
-  );
-};
-
-const defaultAssignments = () => {
-  return runProgram(
-    (function*() {
-      yield withHandler(
-        {
-          *getDefault(__e__, resume) {
-            const result = yield function(handler) {
-              return new Promise(async (res, rej) => {
-                try {
-                  __e__.data =
-                    typeof __e__.data !== "undefined" ? __e__.data : "default";
-                  return stackResume(handler, __e__.data)
-                    .then(res)
-                    .catch(rej);
-                } catch (handlerError) {
-                  rej(handlerError);
-                }
-              });
-            };
-            return yield resume(result);
-          }
-        },
-        (async function*() {
-          return yield performEffect({
-            type: "getDefault"
-          });
-        })()
-      );
-    })()
-  );
-};
-
-module.exports.test = ({ it, expect, describe, code }) => {
-  describe("Destructuring effects handlers", () => {
-    it("Should destructure effect types in handle block", async () => {
-      const result = await typeDestructure();
-      expect(result).toBe("Hello :)");
-    });
-    it("Should destructure props from performed effects", async () => {
-      console.log(code);
-      const result = await propDestructure(0);
-      expect(result).toBe(4);
-    });
-    it("Should handle rest props correctly during the destructure", async () => {
-      const [data1, data2] = await restDestructure();
-      expect(data1).toBe("example 1 data 1");
-      expect(data2).toBe("example 1 data 2");
-    });
-    it("Should handle default destructure props", async () => {
-      const result = await defaultAssignments();
-      expect(result).toBe("default");
-    });
+module.exports.test = ({ expect, it }) => {
+  it("Should call entries concurrently", async () => {
+    const [t1, t2] = await Promise.all([mainConcurrent(), mainConcurrent()]);
+    expect(Math.abs(t1 - t2)).toBeLessThan(1);
+  });
+  it("Should perform as expected with locked resources", async () => {
+    const [t1, t2] = await Promise.all([
+      mainMutex("A"),
+      new Promise(res =>
+        setTimeout(() => {
+          res(mainMutex("B"));
+        }, 1)
+      )
+    ]);
+    expect(t2).toBeGreaterThan(t1);
+    expect(t2 - t1).toBeGreaterThan(15);
+    expect(someSingletonMutex.data).toBe("B");
   });
 };
 
 
 `;
 
-exports[`transformEffects Transform proposed effects keywords into working JS errors-in-handlers.js: errors-in-handlers.js 1`] = `
+exports[`transformEffects Transform proposed effects keywords into working JS 4. Transform Effects: 4. Transform Effects 1`] = `
 
 const ejectType = 'throwErrorHandler';
 const EjectEffect = () => ({type : ejectType});
@@ -697,8 +383,10 @@ const syncEjectCase = () => {
     'use effects';
     try{
         perform EjectEffect();
-    }handle ejectType with (e){
-        syncEject();
+    }handle(e){
+        if(e.type === ejectType){
+            syncEject();
+        }
     }
 };
 
@@ -706,8 +394,10 @@ const asyncEjectCase = async () => {
     'use effects';
     try{
         perform EjectEffect();
-    }handle ejectType with (e){
-        await asyncEject();
+    }handle(e){
+        if(e.type === ejectType){
+            await asyncEject();
+        }
     }
 };
 
@@ -715,8 +405,10 @@ const continuationEjectCase = () => {
   'use effects';
   try{
 
-  }handle ejectType with (e){
-      continuationEject();
+  }handle(e){
+      if(e.type === ejectType){
+          continuationEject();
+      }
   }
 };
 
@@ -747,7 +439,7 @@ const syncEjectCase = () => {
     (function*() {
       yield withHandler(
         {
-          *[ejectType](__e__, resume) {
+          *throwErrorHandler(__e__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -777,7 +469,7 @@ const asyncEjectCase = async () => {
     (function*() {
       yield withHandler(
         {
-          *[ejectType](__e__, resume) {
+          *throwErrorHandler(__e__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -810,7 +502,7 @@ const continuationEjectCase = () => {
     (function*() {
       yield withHandler(
         {
-          *[ejectType](__e__, resume) {
+          *throwErrorHandler(__e__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -850,21 +542,25 @@ module.exports.test = async ({ it, expect, code }) => {
 
 `;
 
-exports[`transformEffects Transform proposed effects keywords into working JS nesting-handlers.js: nesting-handlers.js 1`] = `
+exports[`transformEffects Transform proposed effects keywords into working JS 5. Transform Effects: 5. Transform Effects 1`] = `
 
 const mainEffectHandler = (input) => {
     try{
        return input()
-    }handle 'main' with (e){
-        recall {value : "main"}
+    }handle(e){
+        if(e.type === 'main'){
+            recall {value : "main"}
+        }
     }
 };
 
 const childEffectHandler = (input) => {
     try{
         return input();
-    }handle 'child' with (e){
-        recall {value : "child"}
+    }handle(e){
+        if(e.type === 'child'){
+            recall {value : "child"}
+        }
     }
 };
 
@@ -1023,13 +719,15 @@ module.exports.test = ({ it, expect }) => {
 
 `;
 
-exports[`transformEffects Transform proposed effects keywords into working JS normal-functions.js: normal-functions.js 1`] = `
+exports[`transformEffects Transform proposed effects keywords into working JS 6. Transform Effects: 6. Transform Effects 1`] = `
 
 const mainEffectHandler = (input) => {
     try{
         return input()
-    }handle 'main' with (e){
-        recall {value : "main"}
+    }handle(e){
+        if(e.type === 'main'){
+            recall {value : "main"}
+        }
     }
 };
 
@@ -1113,7 +811,7 @@ module.exports.test = ({ it, expect, code }) => {
 
 `;
 
-exports[`transformEffects Transform proposed effects keywords into working JS perform-async-get-integer-control-flow.js: perform-async-get-integer-control-flow.js 1`] = `
+exports[`transformEffects Transform proposed effects keywords into working JS 7. Transform Effects: 7. Transform Effects 1`] = `
 
 const getIntegerHandler = 'getInteger';
 
@@ -1125,8 +823,10 @@ const main = async () => {
     'use effects';
     try{
         return await asyncChild();
-    }handle getIntegerHandler with (e){
-        recall expectation;
+    }handle(e){
+        if(e.type === getIntegerHandler){
+            recall expectation;
+        }
     }
 };
 
@@ -1160,7 +860,7 @@ const main = async () => {
     (function*() {
       yield withHandler(
         {
-          *[getIntegerHandler](__e__, resume) {
+          *getInteger(__e__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -1199,7 +899,7 @@ module.exports.test = ({ it, expect, code }) => {
 
 `;
 
-exports[`transformEffects Transform proposed effects keywords into working JS perform-async-get-integer-handler.js: perform-async-get-integer-handler.js 1`] = `
+exports[`transformEffects Transform proposed effects keywords into working JS 8. Transform Effects: 8. Transform Effects 1`] = `
 
 const getAsyncIntegerHandler = 'getAsyncInteger';
 
@@ -1213,10 +913,12 @@ const main = ({onEffectComplete}) => {
         const result = perform GetAsyncIntegerEffect();
 
         onEffectComplete(result);
-    }handle getAsyncIntegerHandler with (e){
-        setTimeout(() => {
-            recall expectation;
-        }, 50)
+    }handle(e){
+        if(e.type === getAsyncIntegerHandler){
+            setTimeout(() => {
+                recall expectation;
+            }, 50)
+        }
     }
 };
 
@@ -1240,7 +942,7 @@ const main = ({ onEffectComplete }) => {
     (function*() {
       yield withHandler(
         {
-          *[getAsyncIntegerHandler](__e__, resume) {
+          *getAsyncInteger(__e__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -1274,7 +976,7 @@ module.exports = {
 
 `;
 
-exports[`transformEffects Transform proposed effects keywords into working JS perform-get-integer.js: perform-get-integer.js 1`] = `
+exports[`transformEffects Transform proposed effects keywords into working JS 9. Transform Effects: 9. Transform Effects 1`] = `
 
 const getIntegerHandler = 'getInteger';
 
@@ -1286,8 +988,10 @@ const main = async () => {
         const integer = perform GetIntegerEffect();
 
         return integer
-    }handle getIntegerHandler with (e){
-        recall 5;
+    }handle(e){
+        if(e.type === getIntegerHandler){
+            recall 5;
+        }
     }
 }
 
@@ -1312,7 +1016,7 @@ const main = async () => {
     (function*() {
       yield withHandler(
         {
-          *[getIntegerHandler](__e__, resume) {
+          *getInteger(__e__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -1346,7 +1050,7 @@ module.exports.test = ({ it, expect, code }) => {
 
 `;
 
-exports[`transformEffects Transform proposed effects keywords into working JS switch-statement.js: switch-statement.js 1`] = `
+exports[`transformEffects Transform proposed effects keywords into working JS 10. Transform Effects: 10. Transform Effects 1`] = `
 
 const effectTypeA = 'typeA';
 const effectTypeB = 'typeB';
@@ -1371,12 +1075,12 @@ const cHandler = () => {
 const main = (fn) => {
     try{
         return fn();
-    }handle effectTypeA with (e) {
-        aHandler();
-    }handle effectTypeB with (e) {
-        bHandler();
-    }handle effectTypeC with (e) {
-        cHandler();
+    }handle(e){
+        switch(e){
+            case effectTypeA : return aHandler();
+            case effectTypeB : return bHandler();
+            case effectTypeC : return cHandler();
+        }
     }
 };
 
@@ -1454,7 +1158,7 @@ const EffectC = () => ({
 const main = function*(fn) {
   return yield withHandler(
     {
-      *[effectTypeA](__e__, resume) {
+      *typeA(__e__, resume) {
         const result = yield function(handler) {
           return new Promise(async (res, rej) => {
             try {
@@ -1464,7 +1168,7 @@ const main = function*(fn) {
                   .catch(rej);
               };
 
-              aHandler();
+              return aHandler();
             } catch (handlerError) {
               rej(handlerError);
             }
@@ -1473,7 +1177,7 @@ const main = function*(fn) {
         return yield resume(result);
       },
 
-      *[effectTypeB](__e__, resume) {
+      *typeB(__e__, resume) {
         const result = yield function(handler) {
           return new Promise(async (res, rej) => {
             try {
@@ -1483,7 +1187,7 @@ const main = function*(fn) {
                   .catch(rej);
               };
 
-              bHandler();
+              return bHandler();
             } catch (handlerError) {
               rej(handlerError);
             }
@@ -1492,7 +1196,7 @@ const main = function*(fn) {
         return yield resume(result);
       },
 
-      *[effectTypeC](__e__, resume) {
+      *typeC(__e__, resume) {
         const result = yield function(handler) {
           return new Promise(async (res, rej) => {
             try {
@@ -1502,7 +1206,7 @@ const main = function*(fn) {
                   .catch(rej);
               };
 
-              cHandler();
+              return cHandler();
             } catch (handlerError) {
               rej(handlerError);
             }
@@ -1583,7 +1287,7 @@ module.exports.test = ({ it, describe, expect, code }) => {
 
 `;
 
-exports[`transformEffects Transform proposed effects keywords into working JS throwing-errors-from-timers.js: throwing-errors-from-timers.js 1`] = `
+exports[`transformEffects Transform proposed effects keywords into working JS 11. Transform Effects: 11. Transform Effects 1`] = `
 
 const gatherBananasEffectType = 'throwErrorHandler';
 const GatherBananasEffect = () => ({type : gatherBananasEffectType});
@@ -1602,8 +1306,10 @@ const main = async () => {
         if(someBananas === 'A Bunch Of Bananas'){
             throw new Error('I wanted Plantains!');
         }
-    }handle gatherBananasEffectType with (e){
-        gatherBananasHandler();
+    }handle(e){
+        if(e.type === gatherBananasEffectType){
+            gatherBananasHandler();
+        }
     }
 
 };
@@ -1627,7 +1333,7 @@ const main = async () => {
     (function*() {
       yield withHandler(
         {
-          *[gatherBananasEffectType](__e__, resume) {
+          *throwErrorHandler(__e__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {


### PR DESCRIPTION
## problem

see #14 
see https://github.com/dpchamps/babel/pull/1

## solution

* Update Traverse Plugin to traverse the new AST topology
* Implement default effects handlers in the runtime.
* Update unit, integration and functional tests for the new grammar and default handlers


closes #14 