### PR TITLE
fix/effect-handler-regression

### DIFF
--- a/packages/effects-docs/src/pages/examples/get-http-resource.js.example
+++ b/packages/effects-docs/src/pages/examples/get-http-resource.js.example
@@ -2,11 +2,10 @@ function main () {
   'use effects'
   try {
     analyzePage() // observe, _not_ async!
-  } handle (evt) {
-    switch (evt.type) {
-      case 'get_page_size': getPageSize(evt.payload.url).then(size => { recall size })
-      case 'flush_analysis': flushAnalysis(evt.payload).then(metadata => { recall metadata })
-    }
+  } handle 'get_page_size' with (evt) {
+    getPageSize(evt.payload.url).then(size => { recall size });
+  } handle 'flush_analysis' with (evt) {
+    flushAnalysis(evt.payload).then(metadata => { recall metadata });
   }
 }
 

--- a/packages/effects-docs/src/pages/examples/get-integer.js.example
+++ b/packages/effects-docs/src/pages/examples/get-integer.js.example
@@ -3,10 +3,8 @@ const main = async () => {
   try{
     const integer = perform { type: 'get_int' }
     console.log({ integer, ok: 5 === integer })
-  } handle(e) {
-    if (e.type === 'get_int') {
-        recall 5;
-    }
+  } handle 'get_int' with (e) {
+    recall 5;
   }
 }
 main()

--- a/packages/effects-docs/src/pages/index/example-snippet.ts
+++ b/packages/effects-docs/src/pages/index/example-snippet.ts
@@ -1,12 +1,8 @@
 'use effects'
 try {
   await work()
-} handle (event) {
-  switch event.type {
-    case 'log': {
-      console.log(event.message)
-      recall null
-    }
+} handle 'log' with ({message}) {
+      console.log(message)
   }
 }
 

--- a/packages/effects-docs/src/pages/index/keywords.md
+++ b/packages/effects-docs/src/pages/index/keywords.md
@@ -6,4 +6,4 @@ title: index_keywords
 | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `perform` | Initiates an effect. The current function halts, and later resumes when an effect handler `resume`s                                                                    |
 | `handle`  | `try/handle` blocks allow users to specify handlers for effect events, using well-known `try/catch`-like semantics.  `try/handle` is _not_ compatible with `try/catch` |
-| `resume`  | Resumes the previously halted function, who called `perform`.                                                                                                          |
+| `recall`  | Recalls the previously halted function, who called `perform`.                                                                                                          |

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/data-passing.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/data-passing.js
@@ -1,0 +1,44 @@
+const main = () => {
+    'use effects';
+    try{
+        return perform {type : 'effect', data : 'data'}
+    }handle 'effect' with (e){
+        recall e.data
+    }
+};
+
+const dynamicEffect = (effect) => {
+    'use effects';
+    try{
+        return perform effect;
+    }handle 'effectA' with (e){
+        recall 'effectA';
+    }handle 'effectB' with (e){
+        if(e.data === 1){
+            recall true;
+        } else {
+            recall false;
+        }
+    }
+}
+module.exports.test = ({it, expect}) => {
+    it('Should pass data into handler variable', async () => {
+        const result = await main();
+
+        expect(result).toBe('data');
+    });
+
+    it('Should respond to dynamic effect passing', async () => {
+        const result = await dynamicEffect({type : 'effectA'});
+
+        expect(result).toBe('effectA');
+    });
+
+    it('Should recall dynamically', async () => {
+        const resultA = await dynamicEffect({type : 'effectB', data : 1});
+        const resultB = await dynamicEffect({type : 'effectB', data : 2});
+
+        expect(resultA).toBe(true);
+        expect(resultB).toBe(false);
+    })
+};

--- a/packages/effects-runtime/test/__snapshots__/babel-plugin-transform-effects.spec.ts.snap
+++ b/packages/effects-runtime/test/__snapshots__/babel-plugin-transform-effects.spec.ts.snap
@@ -325,6 +325,163 @@ module.exports.test = ({ describe, it, code, expect }) => {
 
 `;
 
+exports[`transformEffects Transform proposed effects keywords into working JS data-passing.js: data-passing.js 1`] = `
+
+const main = () => {
+    'use effects';
+    try{
+        return perform {type : 'effect', data : 'data'}
+    }handle 'effect' with (e){
+        recall e.data
+    }
+};
+
+const dynamicEffect = (effect) => {
+    'use effects';
+    try{
+        return perform effect;
+    }handle 'effectA' with (e){
+        recall 'effectA';
+    }handle 'effectB' with (e){
+        if(e.data === 1){
+            recall true;
+        } else {
+            recall false;
+        }
+    }
+}
+module.exports.test = ({it, expect}) => {
+    it('Should pass data into handler variable', async () => {
+        const result = await main();
+
+        expect(result).toBe('data');
+    });
+
+    it('Should respond to dynamic effect passing', async () => {
+        const result = await dynamicEffect({type : 'effectA'});
+
+        expect(result).toBe('effectA');
+    });
+
+    it('Should recall dynamically', async () => {
+        const resultA = await dynamicEffect({type : 'effectB', data : 1});
+        const resultB = await dynamicEffect({type : 'effectB', data : 2});
+
+        expect(resultA).toBe(true);
+        expect(resultB).toBe(false);
+    })
+};
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const main = () => {
+  return runProgram(
+    (function*() {
+      yield withHandler(
+        {
+          *effect(__e__, resume) {
+            const result = yield function(handler) {
+              return new Promise(async (res, rej) => {
+                try {
+                  return stackResume(handler, __e__.data)
+                    .then(res)
+                    .catch(rej);
+                } catch (handlerError) {
+                  rej(handlerError);
+                }
+              });
+            };
+            return yield resume(result);
+          }
+        },
+        (async function*() {
+          return yield performEffect({
+            type: "effect",
+            data: "data"
+          });
+        })()
+      );
+    })()
+  );
+};
+
+const dynamicEffect = effect => {
+  return runProgram(
+    (function*() {
+      yield withHandler(
+        {
+          *effectA(__e__, resume) {
+            const result = yield function(handler) {
+              return new Promise(async (res, rej) => {
+                try {
+                  return stackResume(handler, "effectA")
+                    .then(res)
+                    .catch(rej);
+                } catch (handlerError) {
+                  rej(handlerError);
+                }
+              });
+            };
+            return yield resume(result);
+          },
+
+          *effectB(__e__, resume) {
+            const result = yield function(handler) {
+              return new Promise(async (res, rej) => {
+                try {
+                  if (__e__.data === 1) {
+                    return stackResume(handler, true)
+                      .then(res)
+                      .catch(rej);
+                  } else {
+                    return stackResume(handler, false)
+                      .then(res)
+                      .catch(rej);
+                  }
+                } catch (handlerError) {
+                  rej(handlerError);
+                }
+              });
+            };
+            return yield resume(result);
+          }
+        },
+        (async function*() {
+          return yield performEffect(effect);
+        })()
+      );
+    })()
+  );
+};
+
+module.exports.test = ({ it, expect }) => {
+  it("Should pass data into handler variable", async () => {
+    const result = await main();
+    expect(result).toBe("data");
+  });
+  it("Should respond to dynamic effect passing", async () => {
+    const result = await dynamicEffect({
+      type: "effectA"
+    });
+    expect(result).toBe("effectA");
+  });
+  it("Should recall dynamically", async () => {
+    const resultA = await dynamicEffect({
+      type: "effectB",
+      data: 1
+    });
+    const resultB = await dynamicEffect({
+      type: "effectB",
+      data: 2
+    });
+    expect(resultA).toBe(true);
+    expect(resultB).toBe(false);
+  });
+};
+
+
+`;
+
 exports[`transformEffects Transform proposed effects keywords into working JS default-handlers.js: default-handlers.js 1`] = `
 
 const effectType = Symbol();


### PR DESCRIPTION
# problem

Swapping to the matcher-esque handlers introduced a regression.

# solution

Fixed the regression, and updated the out of date examples while I was at it.