### PR TITLE
tests: fix hello-world

### DIFF
--- a/packages/effects-runtime/test/__fixtures__/functional-tests/hello-world-multi-perform.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/hello-world-multi-perform.js
@@ -2,25 +2,26 @@ function main () {
   'use effects'
   try {
     return getMessage({
-      numberOfPersons: 7700000000
+      population: 7700000000
     })
   } handle 'get_greeting' with (evt) {
     recall 'Hello'
-  } handle 'get_audience' with ({ payload: { numberOfPersons } }) {
-    if (numberOfPersons > 7e7) recall 'world'
-    else if (numberOfPersons > 1) recall 'friends'
-    else if (numberOfPersons === 1) recall 'friend'
+  } handle 'get_audience' with (evt) {
+    const { payload: population } = evt
+    if (population > 7e7) recall 'world'
+    else if (population > 1) recall 'friends'
+    else if (population === 1) recall 'friend'
     else recall 'no one'
   }
 }
 
-function getMessage ({ numberOfPersons }) {
+function getMessage ({ population }) {
   const greeting = perform { type: 'get_greeting' }
-  return `${greeting}, ${getAudience({ numberOfPersons })}!`
+  return `${greeting}, ${getAudience(population)}!`
 }
 
-function getAudience ({ numberOfPersons }) {
-  perform { type: 'get_audience', payload: numberOfPersons }
+function getAudience (population) {
+  return perform { type: 'get_audience', payload: population }
 }
 
 module.exports.test = ({it, expect}) => {

--- a/packages/effects-runtime/test/__snapshots__/babel-plugin-transform-effects.spec.ts.snap
+++ b/packages/effects-runtime/test/__snapshots__/babel-plugin-transform-effects.spec.ts.snap
@@ -1005,25 +1005,26 @@ function main () {
   'use effects'
   try {
     return getMessage({
-      numberOfPersons: 7700000000
+      population: 7700000000
     })
   } handle 'get_greeting' with (evt) {
     recall 'Hello'
-  } handle 'get_audience' with ({ payload: { numberOfPersons } }) {
-    if (numberOfPersons > 7e7) recall 'world'
-    else if (numberOfPersons > 1) recall 'friends'
-    else if (numberOfPersons === 1) recall 'friend'
+  } handle 'get_audience' with (evt) {
+    const { payload: population } = evt
+    if (population > 7e7) recall 'world'
+    else if (population > 1) recall 'friends'
+    else if (population === 1) recall 'friend'
     else recall 'no one'
   }
 }
 
-function getMessage ({ numberOfPersons }) {
+function getMessage ({ population }) {
   const greeting = perform { type: 'get_greeting' }
-  return \`\${greeting}, \${getAudience({ numberOfPersons })}!\`
+  return \`\${greeting}, \${getAudience(population)}!\`
 }
 
-function getAudience ({ numberOfPersons }) {
-  perform { type: 'get_audience', payload: numberOfPersons }
+function getAudience (population) {
+  return perform { type: 'get_audience', payload: population }
 }
 
 module.exports.test = ({it, expect}) => {
@@ -1055,19 +1056,20 @@ function main() {
             return yield resume(result);
           },
 
-          *get_audience(__e__, resume) {
+          *get_audience(__evt__, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
-                  if (numberOfPersons > 7e7)
+                  const { payload: population } = __evt__;
+                  if (population > 7e7)
                     return stackResume(handler, "world")
                       .then(res)
                       .catch(rej);
-                  else if (numberOfPersons > 1)
+                  else if (population > 1)
                     return stackResume(handler, "friends")
                       .then(res)
                       .catch(rej);
-                  else if (numberOfPersons === 1)
+                  else if (population === 1)
                     return stackResume(handler, "friend")
                       .then(res)
                       .catch(rej);
@@ -1085,7 +1087,7 @@ function main() {
         },
         (async function*() {
           return yield getMessage({
-            numberOfPersons: 7700000000
+            population: 7700000000
           });
         })()
       );
@@ -1093,19 +1095,17 @@ function main() {
   );
 }
 
-function* getMessage({ numberOfPersons }) {
+function* getMessage({ population }) {
   const greeting = yield performEffect({
     type: "get_greeting"
   });
-  return \`\${greeting}, \${yield getAudience({
-    numberOfPersons
-  })}!\`;
+  return \`\${greeting}, \${yield getAudience(population)}!\`;
 }
 
-function* getAudience({ numberOfPersons }) {
-  yield performEffect({
+function* getAudience(population) {
+  return yield performEffect({
     type: "get_audience",
-    payload: numberOfPersons
+    payload: population
   });
 }
 


### PR DESCRIPTION
# problem

two parts!

**p1**

`} handle 'get_audience' with (evt) { // ok`, but destructured

`} handle 'get_audience' with ({ payload: mappedToNewName }) { // not ok`

the compiled block looks like

```
*get_audience(__e__, resume) { // __e__ vs { payload: mappedToNewName }
  const result = yield function (handler) {
    return new Promise(async (res, rej) => {
      try {
        if (population > 7e7) return stackResume(handler, 'world').then(res).catch(rej);
        ...
      } catch (handlerError) {
        rej(handlerError);
      }
    });
  ...
```

**p2**

missing `return` in `getAudience`