### PR TITLE
Chore/refactor txfm plugin

### DIFF
--- a/packages/babel-plugin-effects/src/plugin.ts
+++ b/packages/babel-plugin-effects/src/plugin.ts
@@ -4,6 +4,7 @@ import BabelTypes, { ObjectExpression, TryStatement } from "@babel/types";
 import { effectsDirectiveVisitor } from "./effects-directive-visitor";
 import { followHandlerDefinitions } from "./handler-method-visitor";
 import { fixupParentGenerator } from "./traverse-utilities";
+import { removeOnExitVisitor } from "./remove-on-exit-visitor";
 const parser = require("../../../babel/packages/babel-parser/lib");
 
 export interface Plugin {
@@ -66,6 +67,7 @@ export default function transformEffects({ types }: Babel): Plugin {
             },
             { types }
           );
+          path.traverse(removeOnExitVisitor, { types });
         }
       },
       TryStatement: {

--- a/packages/babel-plugin-effects/src/remove-on-exit-visitor.ts
+++ b/packages/babel-plugin-effects/src/remove-on-exit-visitor.ts
@@ -1,0 +1,18 @@
+import { Visitor } from "@babel/traverse";
+import { TypesVisitorPrototype } from "./visitor-proto-interfaces";
+import { Expression } from "@babel/types";
+
+const REMOVAL_FIELD = Symbol();
+/**
+ * Visit recall statements and convert them to an interpreted stack frame call.
+ */
+export const removeOnExitVisitor: Visitor<TypesVisitorPrototype> = {
+  Declaration(path, { types }) {
+    if (path[REMOVAL_FIELD] === true) {
+      path.remove();
+    }
+  }
+};
+
+export const markPathForRemoval = (path: Expression) =>
+  (path[REMOVAL_FIELD] = true);

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/composable-recall-statements.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/composable-recall-statements.js
@@ -1,10 +1,12 @@
 const effectTypeA = 'typeA';
 const effectTypeB = 'typeB';
 const effectTypeC = 'typeC';
+const effectTypeD = 'typeD';
 
 const EffectA = () => ({type : effectTypeA});
 const EffectB = () => ({type : effectTypeB});
 const EffectC = () => ({type : effectTypeC});
+const EffectD = (data) => ({type : effectTypeD, data});
 
 const aHandler = () => {
   recall effectTypeA;
@@ -27,6 +29,13 @@ const main = (fn) => {
         bHandler();
     }handle effectTypeC with (e) {
         cHandler();
+    }handle effectTypeD with (e) {
+        switch(e.data){
+            case 1 : return aHandler();
+            case 2 : return bHandler();
+            case 3 : return cHandler();
+            default : return recall "bazinga";
+        }
     }
 };
 
@@ -51,6 +60,13 @@ const performCTest = () => {
     });
 };
 
+const performDTest = (input) => {
+    'use effects';
+    main(() => {
+        return perform EffectD(input);
+    })
+};
+
 const performAllTest = () => {
     'use effects'
     main(() => {
@@ -73,6 +89,21 @@ module.exports.test = ({it, describe, expect, code}) => {
         it('Should perform effect C', async () => {
             const result = await performCTest();
             expect(result).toBe(effectTypeC);
+        });
+
+    });
+
+    describe('Overlapping recall statements', () => {
+        it('Should perform recall functions referenced in multiple places without cause', async () => {
+            const resultA = await performDTest(1);
+            const resultB = await performDTest(2);
+            const resultC = await performDTest(3);
+            const bazinga = await performDTest('bazinga');
+
+            expect(resultA).toBe(effectTypeA);
+            expect(resultB).toBe(effectTypeB);
+            expect(resultC).toBe(effectTypeC);
+            expect(bazinga).toBe('bazinga');
         });
     });
 

--- a/packages/effects-runtime/test/__fixtures__/functional-tests/destructure.js
+++ b/packages/effects-runtime/test/__fixtures__/functional-tests/destructure.js
@@ -21,6 +21,22 @@ const propDestructure = (mutableThing) => {
     }
 };
 
+const deepPropDestructuring = (propValue) => {
+    'use effects'
+    try{
+        return perform {
+            type : 'a',
+            payload : {
+                a : {
+                    b : propValue
+                }
+            }
+        }
+    }handle 'a' with ({payload : {a : { b }}}){
+        recall b
+    }
+};
+
 const restDestructure = () => {
   'use effects'
   try{
@@ -51,6 +67,14 @@ module.exports.test = ({it, expect, describe, code}) => {
         it('Should destructure props from performed effects', async () => {
             const result = await propDestructure(0);
            expect(result).toBe(4);
+        });
+
+        it('Should destructure deep props from performed effects', async () => {
+            const expectedResult = 'such deep prop very wow';
+            const result = await deepPropDestructuring(expectedResult);
+
+            expect(result).toBe(expectedResult);
+
         });
 
         it('Should handle rest props correctly during the destructure', async () =>{

--- a/packages/effects-runtime/test/__snapshots__/babel-plugin-transform-effects.spec.ts.snap
+++ b/packages/effects-runtime/test/__snapshots__/babel-plugin-transform-effects.spec.ts.snap
@@ -39,7 +39,7 @@ module.exports.test = ({it, expect, code}) => {
 const entry = function*() {
   return yield withHandler(
     {
-      *[__defaultEffectHandler__](__e__, resume) {
+      *[__defaultEffectHandler__](e, resume) {
         const result = yield function(handler) {
           return new Promise(async (res, rej) => {
             try {
@@ -124,7 +124,7 @@ const main = () => {
     (function*() {
       yield withHandler(
         {
-          *[throwErrorHandler](__e__, resume) {
+          *[throwErrorHandler](e, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -148,6 +148,347 @@ const main = () => {
 module.exports.test = async ({ describe, it, expect }) => {
   it("Should handle errors within effects", async () => {
     await expect(main()).rejects.toThrowError();
+  });
+};
+
+
+`;
+
+exports[`transformEffects Transform proposed effects keywords into working JS composable-recall-statements.js: composable-recall-statements.js 1`] = `
+
+const effectTypeA = 'typeA';
+const effectTypeB = 'typeB';
+const effectTypeC = 'typeC';
+const effectTypeD = 'typeD';
+
+const EffectA = () => ({type : effectTypeA});
+const EffectB = () => ({type : effectTypeB});
+const EffectC = () => ({type : effectTypeC});
+const EffectD = (data) => ({type : effectTypeD, data});
+
+const aHandler = () => {
+  recall effectTypeA;
+};
+
+const bHandler = () => {
+    recall effectTypeB;
+};
+
+const cHandler = () => {
+  recall effectTypeC;
+};
+
+const main = (fn) => {
+    try{
+        return fn();
+    }handle effectTypeA with (e) {
+        aHandler();
+    }handle effectTypeB with (e) {
+        bHandler();
+    }handle effectTypeC with (e) {
+        cHandler();
+    }handle effectTypeD with (e) {
+        switch(e.data){
+            case 1 : return aHandler();
+            case 2 : return bHandler();
+            case 3 : return cHandler();
+            default : return recall "bazinga";
+        }
+    }
+};
+
+const performATest = () => {
+    'use effects'
+    main(() => {
+       return perform EffectA();
+    });
+};
+
+const performBTest = () => {
+    'use effects'
+    main(() => {
+        return perform EffectB();
+    });
+};
+
+const performCTest = () => {
+    'use effects'
+    main(() => {
+        return perform EffectC();
+    });
+};
+
+const performDTest = (input) => {
+    'use effects';
+    main(() => {
+        return perform EffectD(input);
+    })
+};
+
+const performAllTest = () => {
+    'use effects'
+    main(() => {
+        return \`\${perform EffectA()}\${perform EffectB()}\${perform EffectC()}\`;
+    });
+};
+
+module.exports.test = ({it, describe, expect, code}) => {
+    describe('Single effect', () => {
+        it('Should perform effect A', async () => {
+            const result = await performATest();
+            expect(result).toBe(effectTypeA);
+        });
+
+        it('Should perform effect B', async () => {
+            const result = await performBTest();
+            expect(result).toBe(effectTypeB);
+        });
+
+        it('Should perform effect C', async () => {
+            const result = await performCTest();
+            expect(result).toBe(effectTypeC);
+        });
+
+    });
+
+    describe('Overlapping recall statements', () => {
+        it('Should perform recall functions referenced in multiple places without cause', async () => {
+            const resultA = await performDTest(1);
+            const resultB = await performDTest(2);
+            const resultC = await performDTest(3);
+            const bazinga = await performDTest('bazinga');
+
+            expect(resultA).toBe(effectTypeA);
+            expect(resultB).toBe(effectTypeB);
+            expect(resultC).toBe(effectTypeC);
+            expect(bazinga).toBe('bazinga');
+        });
+    });
+
+    it('Should handle all cases', async () => {
+        const result = await performAllTest();
+
+        expect(result).toBe(\`\${effectTypeA}\${effectTypeB}\${effectTypeC}\`);
+    })
+};
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const effectTypeA = "typeA";
+const effectTypeB = "typeB";
+const effectTypeC = "typeC";
+const effectTypeD = "typeD";
+
+const EffectA = () => ({
+  type: effectTypeA
+});
+
+const EffectB = () => ({
+  type: effectTypeB
+});
+
+const EffectC = () => ({
+  type: effectTypeC
+});
+
+const EffectD = data => ({
+  type: effectTypeD,
+  data
+});
+
+const main = function*(fn) {
+  return yield withHandler(
+    {
+      *[effectTypeA](e, resume) {
+        const result = yield function(handler) {
+          return new Promise(async (res, rej) => {
+            try {
+              const aHandler = () => {
+                return stackResume(handler, effectTypeA)
+                  .then(res)
+                  .catch(rej);
+              };
+
+              aHandler();
+            } catch (handlerError) {
+              rej(handlerError);
+            }
+          });
+        };
+        return yield resume(result);
+      },
+
+      *[effectTypeB](e, resume) {
+        const result = yield function(handler) {
+          return new Promise(async (res, rej) => {
+            try {
+              const bHandler = () => {
+                return stackResume(handler, effectTypeB)
+                  .then(res)
+                  .catch(rej);
+              };
+
+              bHandler();
+            } catch (handlerError) {
+              rej(handlerError);
+            }
+          });
+        };
+        return yield resume(result);
+      },
+
+      *[effectTypeC](e, resume) {
+        const result = yield function(handler) {
+          return new Promise(async (res, rej) => {
+            try {
+              const cHandler = () => {
+                return stackResume(handler, effectTypeC)
+                  .then(res)
+                  .catch(rej);
+              };
+
+              cHandler();
+            } catch (handlerError) {
+              rej(handlerError);
+            }
+          });
+        };
+        return yield resume(result);
+      },
+
+      *[effectTypeD](e, resume) {
+        const result = yield function(handler) {
+          return new Promise(async (res, rej) => {
+            try {
+              const aHandler = () => {
+                return stackResume(handler, effectTypeA)
+                  .then(res)
+                  .catch(rej);
+              };
+
+              const bHandler = () => {
+                return stackResume(handler, effectTypeB)
+                  .then(res)
+                  .catch(rej);
+              };
+
+              const cHandler = () => {
+                return stackResume(handler, effectTypeC)
+                  .then(res)
+                  .catch(rej);
+              };
+
+              switch (e.data) {
+                case 1:
+                  return aHandler();
+
+                case 2:
+                  return bHandler();
+
+                case 3:
+                  return cHandler();
+
+                default:
+                  return stackResume(handler, "bazinga")
+                    .then(res)
+                    .catch(rej);
+              }
+            } catch (handlerError) {
+              rej(handlerError);
+            }
+          });
+        };
+        return yield resume(result);
+      }
+    },
+    (async function*() {
+      return yield fn();
+    })()
+  );
+};
+
+const performATest = () => {
+  return runProgram(
+    (function*() {
+      yield main(function*() {
+        return yield performEffect(yield EffectA());
+      });
+    })()
+  );
+};
+
+const performBTest = () => {
+  return runProgram(
+    (function*() {
+      yield main(function*() {
+        return yield performEffect(yield EffectB());
+      });
+    })()
+  );
+};
+
+const performCTest = () => {
+  return runProgram(
+    (function*() {
+      yield main(function*() {
+        return yield performEffect(yield EffectC());
+      });
+    })()
+  );
+};
+
+const performDTest = input => {
+  return runProgram(
+    (function*() {
+      yield main(function*() {
+        return yield performEffect(yield EffectD(input));
+      });
+    })()
+  );
+};
+
+const performAllTest = () => {
+  return runProgram(
+    (function*() {
+      yield main(function*() {
+        return \`\${yield performEffect(
+          yield EffectA()
+        )}\${yield performEffect(yield EffectB())}\${yield performEffect(yield EffectC())}\`;
+      });
+    })()
+  );
+};
+
+module.exports.test = ({ it, describe, expect, code }) => {
+  describe("Single effect", () => {
+    it("Should perform effect A", async () => {
+      const result = await performATest();
+      expect(result).toBe(effectTypeA);
+    });
+    it("Should perform effect B", async () => {
+      const result = await performBTest();
+      expect(result).toBe(effectTypeB);
+    });
+    it("Should perform effect C", async () => {
+      const result = await performCTest();
+      expect(result).toBe(effectTypeC);
+    });
+  });
+  describe("Overlapping recall statements", () => {
+    it("Should perform recall functions referenced in multiple places without cause", async () => {
+      const resultA = await performDTest(1);
+      const resultB = await performDTest(2);
+      const resultC = await performDTest(3);
+      const bazinga = await performDTest("bazinga");
+      expect(resultA).toBe(effectTypeA);
+      expect(resultB).toBe(effectTypeB);
+      expect(resultC).toBe(effectTypeC);
+      expect(bazinga).toBe("bazinga");
+    });
+  });
+  it("Should handle all cases", async () => {
+    const result = await performAllTest();
+    expect(result).toBe(\`\${effectTypeA}\${effectTypeB}\${effectTypeC}\`);
   });
 };
 
@@ -217,7 +558,7 @@ const { computedHandler } = {};
 const main = async function*(fn) {
   return yield withHandler(
     {
-      *[symbolHandler](_____, resume) {
+      *[symbolHandler](_, resume) {
         const result = yield function(handler) {
           return new Promise(async (res, rej) => {
             try {
@@ -232,7 +573,7 @@ const main = async function*(fn) {
         return yield resume(result);
       },
 
-      *[computedHandler](_____, resume) {
+      *[computedHandler](_, resume) {
         const result = yield function(handler) {
           return new Promise(async (res, rej) => {
             try {
@@ -283,7 +624,7 @@ const locallyScopedEffects = async () => {
       const something = "something";
       yield withHandler(
         {
-          *[something](_____, resume) {
+          *[something](_, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -373,7 +714,7 @@ const work = async name => {
     (function*() {
       yield withHandler(
         {
-          *async_identity(__e__, resume) {
+          *async_identity(e, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -381,7 +722,7 @@ const work = async name => {
 
                   const {
                     payload: { name }
-                  } = __e__;
+                  } = e;
                   await delay(name === "a" ? 100 : 1);
                   return stackResume(handler, name)
                     .then(res)
@@ -473,11 +814,11 @@ const main = () => {
     (function*() {
       yield withHandler(
         {
-          *effect(__e__, resume) {
+          *effect(e, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
-                  return stackResume(handler, __e__.data)
+                  return stackResume(handler, e.data)
                     .then(res)
                     .catch(rej);
                 } catch (handlerError) {
@@ -504,7 +845,7 @@ const dynamicEffect = effect => {
     (function*() {
       yield withHandler(
         {
-          *effectA(__e__, resume) {
+          *effectA(e, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -519,11 +860,11 @@ const dynamicEffect = effect => {
             return yield resume(result);
           },
 
-          *effectB(__e__, resume) {
+          *effectB(e, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
-                  if (__e__.data === 1) {
+                  if (e.data === 1) {
                     return stackResume(handler, true)
                       .then(res)
                       .catch(rej);
@@ -612,11 +953,11 @@ const main = async data => {
     (function*() {
       yield withHandler(
         {
-          *[effectType](__e__, resume) {
+          *[effectType]({ data }, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
-                  return stackResume(handler, __e__.data + 1)
+                  return stackResume(handler, data + 1)
                     .then(res)
                     .catch(rej);
                 } catch (handlerError) {
@@ -627,11 +968,11 @@ const main = async data => {
             return yield resume(result);
           },
 
-          *[__defaultEffectHandler__](__e__, resume) {
+          *[__defaultEffectHandler__]({ data }, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
-                  return stackResume(handler, __e__.data * 2)
+                  return stackResume(handler, data * 2)
                     .then(res)
                     .catch(rej);
                 } catch (handlerError) {
@@ -692,6 +1033,22 @@ const propDestructure = (mutableThing) => {
     }
 };
 
+const deepPropDestructuring = (propValue) => {
+    'use effects'
+    try{
+        return perform {
+            type : 'a',
+            payload : {
+                a : {
+                    b : propValue
+                }
+            }
+        }
+    }handle 'a' with ({payload : {a : { b }}}){
+        recall b
+    }
+};
+
 const restDestructure = () => {
   'use effects'
   try{
@@ -724,6 +1081,14 @@ module.exports.test = ({it, expect, describe, code}) => {
            expect(result).toBe(4);
         });
 
+        it('Should destructure deep props from performed effects', async () => {
+            const expectedResult = 'such deep prop very wow';
+            const result = await deepPropDestructuring(expectedResult);
+
+            expect(result).toBe(expectedResult);
+
+        });
+
         it('Should handle rest props correctly during the destructure', async () =>{
             const [data1, data2] = await restDestructure();
 
@@ -746,7 +1111,7 @@ const typeDestructure = () => {
     (function*() {
       yield withHandler(
         {
-          *sayHi(__e__, resume) {
+          *sayHi(e, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -776,11 +1141,11 @@ const propDestructure = mutableThing => {
     (function*() {
       yield withHandler(
         {
-          *addOne(__e__, resume) {
+          *addOne({ data }, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
-                  return stackResume(handler, __e__.data + 1)
+                  return stackResume(handler, data + 1)
                     .then(res)
                     .catch(rej);
                 } catch (handlerError) {
@@ -791,11 +1156,11 @@ const propDestructure = mutableThing => {
             return yield resume(result);
           },
 
-          *addTwo(__e__, resume) {
+          *addTwo({ data }, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
-                  return stackResume(handler, __e__.data + 2)
+                  return stackResume(handler, data + 2)
                     .then(res)
                     .catch(rej);
                 } catch (handlerError) {
@@ -822,16 +1187,58 @@ const propDestructure = mutableThing => {
   );
 };
 
+const deepPropDestructuring = propValue => {
+  return runProgram(
+    (function*() {
+      yield withHandler(
+        {
+          *a(
+            {
+              payload: {
+                a: { b }
+              }
+            },
+            resume
+          ) {
+            const result = yield function(handler) {
+              return new Promise(async (res, rej) => {
+                try {
+                  return stackResume(handler, b)
+                    .then(res)
+                    .catch(rej);
+                } catch (handlerError) {
+                  rej(handlerError);
+                }
+              });
+            };
+            return yield resume(result);
+          }
+        },
+        (async function*() {
+          return yield performEffect({
+            type: "a",
+            payload: {
+              a: {
+                b: propValue
+              }
+            }
+          });
+        })()
+      );
+    })()
+  );
+};
+
 const restDestructure = () => {
   return runProgram(
     (function*() {
       yield withHandler(
         {
-          *example(__e__, resume) {
+          *example({ ...data }, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
-                  const { data1, data2 } = __e__;
+                  const { data1, data2 } = data;
                   return stackResume(handler, [data1, data2])
                     .then(res)
                     .catch(rej);
@@ -860,13 +1267,11 @@ const defaultAssignments = () => {
     (function*() {
       yield withHandler(
         {
-          *getDefault(__e__, resume) {
+          *getDefault({ data = "default" }, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
-                  __e__.data =
-                    typeof __e__.data !== "undefined" ? __e__.data : "default";
-                  return stackResume(handler, __e__.data)
+                  return stackResume(handler, data)
                     .then(res)
                     .catch(rej);
                 } catch (handlerError) {
@@ -896,6 +1301,11 @@ module.exports.test = ({ it, expect, describe, code }) => {
     it("Should destructure props from performed effects", async () => {
       const result = await propDestructure(0);
       expect(result).toBe(4);
+    });
+    it("Should destructure deep props from performed effects", async () => {
+      const expectedResult = "such deep prop very wow";
+      const result = await deepPropDestructuring(expectedResult);
+      expect(result).toBe(expectedResult);
     });
     it("Should handle rest props correctly during the destructure", async () => {
       const [data1, data2] = await restDestructure();
@@ -990,7 +1400,7 @@ const syncEjectCase = () => {
     (function*() {
       yield withHandler(
         {
-          *[ejectType](__e__, resume) {
+          *[ejectType](e, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -1020,7 +1430,7 @@ const asyncEjectCase = async () => {
     (function*() {
       yield withHandler(
         {
-          *[ejectType](__e__, resume) {
+          *[ejectType](e, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -1053,7 +1463,7 @@ const continuationEjectCase = () => {
     (function*() {
       yield withHandler(
         {
-          *[ejectType](__e__, resume) {
+          *[ejectType](e, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -1135,7 +1545,7 @@ function main() {
     (function*() {
       yield withHandler(
         {
-          *get_greeting(__evt__, resume) {
+          *get_greeting(evt, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -1150,11 +1560,11 @@ function main() {
             return yield resume(result);
           },
 
-          *get_audience(__evt__, resume) {
+          *get_audience(evt, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
-                  const { payload: population } = __evt__;
+                  const { payload: population } = evt;
                   if (population > 7e7)
                     return stackResume(handler, "world")
                       .then(res)
@@ -1281,7 +1691,7 @@ module.exports.test = ({it, expect}) => {
 const mainEffectHandler = function*(input) {
   return yield withHandler(
     {
-      *main(__e__, resume) {
+      *main(e, resume) {
         const result = yield function(handler) {
           return new Promise(async (res, rej) => {
             try {
@@ -1307,7 +1717,7 @@ const mainEffectHandler = function*(input) {
 const childEffectHandler = function*(input) {
   return yield withHandler(
     {
-      *child(__e__, resume) {
+      *child(e, resume) {
         const result = yield function(handler) {
           return new Promise(async (res, rej) => {
             try {
@@ -1424,7 +1834,7 @@ module.exports.test = ({it, expect, code}) => {
 const mainEffectHandler = function*(input) {
   return yield withHandler(
     {
-      *main(__e__, resume) {
+      *main(e, resume) {
         const result = yield function(handler) {
           return new Promise(async (res, rej) => {
             try {
@@ -1523,7 +1933,7 @@ const main = async () => {
     (function*() {
       yield withHandler(
         {
-          *[getIntegerHandler](__e__, resume) {
+          *[getIntegerHandler](e, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -1603,7 +2013,7 @@ const main = ({ onEffectComplete }) => {
     (function*() {
       yield withHandler(
         {
-          *[getAsyncIntegerHandler](__e__, resume) {
+          *[getAsyncIntegerHandler](e, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -1675,7 +2085,7 @@ const main = async () => {
     (function*() {
       yield withHandler(
         {
-          *[getIntegerHandler](__e__, resume) {
+          *[getIntegerHandler](e, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {
@@ -1703,243 +2113,6 @@ module.exports.test = ({ it, expect, code }) => {
   it("Should compile, and return expected results", async () => {
     const result = await main();
     expect(result).toBe(5);
-  });
-};
-
-
-`;
-
-exports[`transformEffects Transform proposed effects keywords into working JS switch-statement.js: switch-statement.js 1`] = `
-
-const effectTypeA = 'typeA';
-const effectTypeB = 'typeB';
-const effectTypeC = 'typeC';
-
-const EffectA = () => ({type : effectTypeA});
-const EffectB = () => ({type : effectTypeB});
-const EffectC = () => ({type : effectTypeC});
-
-const aHandler = () => {
-  recall effectTypeA;
-};
-
-const bHandler = () => {
-    recall effectTypeB;
-};
-
-const cHandler = () => {
-  recall effectTypeC;
-};
-
-const main = (fn) => {
-    try{
-        return fn();
-    }handle effectTypeA with (e) {
-        aHandler();
-    }handle effectTypeB with (e) {
-        bHandler();
-    }handle effectTypeC with (e) {
-        cHandler();
-    }
-};
-
-const performATest = () => {
-    'use effects'
-    main(() => {
-       return perform EffectA();
-    });
-};
-
-const performBTest = () => {
-    'use effects'
-    main(() => {
-        return perform EffectB();
-    });
-};
-
-const performCTest = () => {
-    'use effects'
-    main(() => {
-        return perform EffectC();
-    });
-};
-
-const performAllTest = () => {
-    'use effects'
-    main(() => {
-        return \`\${perform EffectA()}\${perform EffectB()}\${perform EffectC()}\`;
-    });
-};
-
-module.exports.test = ({it, describe, expect, code}) => {
-    describe('Single effect', () => {
-        it('Should perform effect A', async () => {
-            const result = await performATest();
-            expect(result).toBe(effectTypeA);
-        });
-
-        it('Should perform effect B', async () => {
-            const result = await performBTest();
-            expect(result).toBe(effectTypeB);
-        });
-
-        it('Should perform effect C', async () => {
-            const result = await performCTest();
-            expect(result).toBe(effectTypeC);
-        });
-    });
-
-    it('Should handle all cases', async () => {
-        const result = await performAllTest();
-
-        expect(result).toBe(\`\${effectTypeA}\${effectTypeB}\${effectTypeC}\`);
-    })
-};
-
-      ↓ ↓ ↓ ↓ ↓ ↓
-
-const effectTypeA = "typeA";
-const effectTypeB = "typeB";
-const effectTypeC = "typeC";
-
-const EffectA = () => ({
-  type: effectTypeA
-});
-
-const EffectB = () => ({
-  type: effectTypeB
-});
-
-const EffectC = () => ({
-  type: effectTypeC
-});
-
-const main = function*(fn) {
-  return yield withHandler(
-    {
-      *[effectTypeA](__e__, resume) {
-        const result = yield function(handler) {
-          return new Promise(async (res, rej) => {
-            try {
-              const aHandler = () => {
-                return stackResume(handler, effectTypeA)
-                  .then(res)
-                  .catch(rej);
-              };
-
-              aHandler();
-            } catch (handlerError) {
-              rej(handlerError);
-            }
-          });
-        };
-        return yield resume(result);
-      },
-
-      *[effectTypeB](__e__, resume) {
-        const result = yield function(handler) {
-          return new Promise(async (res, rej) => {
-            try {
-              const bHandler = () => {
-                return stackResume(handler, effectTypeB)
-                  .then(res)
-                  .catch(rej);
-              };
-
-              bHandler();
-            } catch (handlerError) {
-              rej(handlerError);
-            }
-          });
-        };
-        return yield resume(result);
-      },
-
-      *[effectTypeC](__e__, resume) {
-        const result = yield function(handler) {
-          return new Promise(async (res, rej) => {
-            try {
-              const cHandler = () => {
-                return stackResume(handler, effectTypeC)
-                  .then(res)
-                  .catch(rej);
-              };
-
-              cHandler();
-            } catch (handlerError) {
-              rej(handlerError);
-            }
-          });
-        };
-        return yield resume(result);
-      }
-    },
-    (async function*() {
-      return yield fn();
-    })()
-  );
-};
-
-const performATest = () => {
-  return runProgram(
-    (function*() {
-      yield main(function*() {
-        return yield performEffect(yield EffectA());
-      });
-    })()
-  );
-};
-
-const performBTest = () => {
-  return runProgram(
-    (function*() {
-      yield main(function*() {
-        return yield performEffect(yield EffectB());
-      });
-    })()
-  );
-};
-
-const performCTest = () => {
-  return runProgram(
-    (function*() {
-      yield main(function*() {
-        return yield performEffect(yield EffectC());
-      });
-    })()
-  );
-};
-
-const performAllTest = () => {
-  return runProgram(
-    (function*() {
-      yield main(function*() {
-        return \`\${yield performEffect(
-          yield EffectA()
-        )}\${yield performEffect(yield EffectB())}\${yield performEffect(yield EffectC())}\`;
-      });
-    })()
-  );
-};
-
-module.exports.test = ({ it, describe, expect, code }) => {
-  describe("Single effect", () => {
-    it("Should perform effect A", async () => {
-      const result = await performATest();
-      expect(result).toBe(effectTypeA);
-    });
-    it("Should perform effect B", async () => {
-      const result = await performBTest();
-      expect(result).toBe(effectTypeB);
-    });
-    it("Should perform effect C", async () => {
-      const result = await performCTest();
-      expect(result).toBe(effectTypeC);
-    });
-  });
-  it("Should handle all cases", async () => {
-    const result = await performAllTest();
-    expect(result).toBe(\`\${effectTypeA}\${effectTypeB}\${effectTypeC}\`);
   });
 };
 
@@ -1990,7 +2163,7 @@ const main = async () => {
     (function*() {
       yield withHandler(
         {
-          *[gatherBananasEffectType](__e__, resume) {
+          *[gatherBananasEffectType](e, resume) {
             const result = yield function(handler) {
               return new Promise(async (res, rej) => {
                 try {

--- a/packages/effects-runtime/test/transform-debug.ts
+++ b/packages/effects-runtime/test/transform-debug.ts
@@ -2,40 +2,35 @@
 
 import { transform } from "../../../babel/packages/babel-core";
 import plugin from "babel-plugin-effects";
-import { readFileSync } from 'fs';
-import path from 'path';
-import {exec} from 'child_process';
+import { readFileSync } from "fs";
+import path from "path";
+import { exec } from "child_process";
 
 const FUNCTIONAL_TEST_DIRECTORY = path.resolve(
-    __dirname,
-    `__fixtures__`,
-    `functional-tests`
+  __dirname,
+  `__fixtures__`,
+  `functional-tests`
 );
 const fixture = process.argv[2];
 
 const readAndParseFile = textFixtureBaseName => {
-    const filename = path.resolve(FUNCTIONAL_TEST_DIRECTORY, textFixtureBaseName);
-    const file = readFileSync(
-        filename,
-        "utf8"
-    );
+  const filename = path.resolve(FUNCTIONAL_TEST_DIRECTORY, textFixtureBaseName);
+  const file = readFileSync(filename, "utf8");
 
-    try {
-        return [file, transform(file, {plugins : [plugin]}).code];
-    } catch (e) {
-        throw new Error(`${filename} failed to parse with ${e.message}`);
-    }
+  try {
+    return [file, transform(file, { plugins: [plugin] }).code];
+  } catch (e) {
+    throw new Error(`${filename} failed to parse with ${e.message}`);
+  }
 };
 
 (async () => {
-    try{
-        const [original, transformation] = readAndParseFile(fixture);
+  try {
+    const [original, transformation] = readAndParseFile(fixture);
 
-        console.log(transformation)
-
-    }catch(e){
-        console.error(`${e.message}`);
-        process.exit(1)
-    }
+    console.log(transformation);
+  } catch (e) {
+    console.error(`${e.message}`);
+    process.exit(1);
+  }
 })();
-

--- a/packages/effects-runtime/test/transform-debug.ts
+++ b/packages/effects-runtime/test/transform-debug.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+import { transform } from "../../../babel/packages/babel-core";
+import plugin from "babel-plugin-effects";
+import { readFileSync } from 'fs';
+import path from 'path';
+import {exec} from 'child_process';
+
+const FUNCTIONAL_TEST_DIRECTORY = path.resolve(
+    __dirname,
+    `__fixtures__`,
+    `functional-tests`
+);
+const fixture = process.argv[2];
+
+const readAndParseFile = textFixtureBaseName => {
+    const filename = path.resolve(FUNCTIONAL_TEST_DIRECTORY, textFixtureBaseName);
+    const file = readFileSync(
+        filename,
+        "utf8"
+    );
+
+    try {
+        return [file, transform(file, {plugins : [plugin]}).code];
+    } catch (e) {
+        throw new Error(`${filename} failed to parse with ${e.message}`);
+    }
+};
+
+(async () => {
+    try{
+        const [original, transformation] = readAndParseFile(fixture);
+
+        console.log(transformation)
+
+    }catch(e){
+        console.error(`${e.message}`);
+        process.exit(1)
+    }
+})();
+


### PR DESCRIPTION
# problem

There were some unnecessary transformations taking place left over from pre-handler-matcher days.

This caused several side-effects: 

* handler variables were rewritten
* object patterns were squashed and we'rent expanded properly

# solution

Now that exactly one handler body corresponds to one effect handler during transformation, variables do not need to be renamed. A handler body may be "shifted" into the effect handler transformation unscathed.

awesome side effect: deeply-nested destructuring of handler props:

```javascript 
}handle 'effect' with ({payload : {a : { b }}}){
```

🎊🎊🎊